### PR TITLE
fix: resolve build configuration and test globals

### DIFF
--- a/dashboard-app/src/components/Timeline.test.tsx
+++ b/dashboard-app/src/components/Timeline.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { Timeline } from './Timeline';
 
 function mockFetch(data: string[]) {
-  global.fetch = vi.fn().mockResolvedValue({ json: async () => data });
+  globalThis.fetch = vi.fn().mockResolvedValue({ json: async () => data });
 }
 
 describe('Timeline', () => {

--- a/dashboard-app/vite.config.ts
+++ b/dashboard-app/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- update Vite config to use Vitest's defineConfig so `test` settings are recognized
- mock `fetch` using `globalThis` in Timeline tests

## Testing
- `npm test` (dashboard-app)
- `npm run lint` (dashboard-app)
- `npm run build` (dashboard-app)
- `npm test` (tiling-services/catalog-api)
- `terraform validate` (infra)


------
https://chatgpt.com/codex/tasks/task_e_68af324b13148323945e5910e2d640bc