### PR TITLE
fix(proxy): enforce Tracestrack API key

### DIFF
--- a/Implementation_Checklist_and_Status.md
+++ b/Implementation_Checklist_and_Status.md
@@ -115,3 +115,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Switched `proxy-server` to `moduleResolution: bundler` to match workspace defaults and eliminate config drift.
   - Files: `proxy-server/tsconfig.json`, `Findings.md`, `Followups.md`
   - Verification: `pnpm lint`, `pnpm test`, `cd proxy-server && pnpm test`
+
+- [x] 2025-08-30 — Tracestrack API key validation and URL fix
+  - Summary: Removed hard-coded Tracestrack API key, enforced `TTRACK_API_KEY` env, returned 503 when missing, and interpolated `z/x/y` in tile URL.
+  - Files: `proxy-server/src/app.ts`, `proxy-server/test/tracestrack.test.ts`
+  - Verification: `pnpm lint`, `pnpm test` (catalog-api failure), `cd proxy-server && pnpm test`

--- a/proxy-server/src/app.ts
+++ b/proxy-server/src/app.ts
@@ -589,12 +589,23 @@ app.get('/api/gibs/redirect', ensureGibsEnabled, shortLived60, redirectGibs);
 app.get('/api/tracestrack/:style/:z/:x/:y.webp', shortLived60, async (req, res) => {
   try {
     const { style, z, x, y } = req.params as Record<string, string>;
-    const apiKey = process.env.TTRACK_API_KEY || 'de6a88653d450364eaf72fd0320291b1';
-    
-    const targetUrl = `https://tile.tracestrack.com/${style}/{z}/{x}/{y}.webp?key=${apiKey}&style=outrun`;
-    
+    const apiKey = process.env.TTRACK_API_KEY;
+    if (!apiKey) {
+      res
+        .status(HTTP_STATUS.SERVICE_UNAVAILABLE)
+        .json(
+          createErrorResponse(
+            HTTP_STATUS.SERVICE_UNAVAILABLE,
+            'Tracestrack API key not configured'
+          )
+        );
+      return;
+    }
+
+    const targetUrl = `https://tile.tracestrack.com/${style}/${z}/${x}/${y}.webp?key=${apiKey}&style=outrun`;
+
     console.log(`Fetching Tracestrack tile from: ${targetUrl}`);
-    
+
     const upstream = await fetchWithRetry(targetUrl, {});
     const buffer = Buffer.from(await upstream.arrayBuffer());
     

--- a/proxy-server/test/tracestrack.test.ts
+++ b/proxy-server/test/tracestrack.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { app } from '../src/app.js';
+
+const originalKey = process.env.TTRACK_API_KEY;
+
+afterEach(() => {
+  if (originalKey) {
+    process.env.TTRACK_API_KEY = originalKey;
+  } else {
+    delete process.env.TTRACK_API_KEY;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('Tracestrack tile proxy', () => {
+  it('returns 503 when key is missing', async () => {
+    delete process.env.TTRACK_API_KEY;
+    const res = await request(app).get('/api/tracestrack/basic/1/2/3.webp');
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/api key/i);
+  });
+
+  it('requests tile with interpolated coordinates when key present', async () => {
+    process.env.TTRACK_API_KEY = 'test-key';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response('ok', {
+          status: 200,
+          headers: { 'content-type': 'image/webp' },
+        }) as any
+      );
+
+    const res = await request(app).get('/api/tracestrack/topo/4/5/6.webp');
+    expect(res.status).toBe(200);
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(
+      'https://tile.tracestrack.com/topo/4/5/6.webp?key=test-key&style=outrun'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove hard-coded Tracestrack key and require `TTRACK_API_KEY`
- interpolate tile coordinates and guard with 503 when key missing
- add tests covering missing key and URL formation

## Testing
- `pnpm lint`
- `pnpm test` (fails: catalog-api@0.1.0 test: node --test)
- `cd proxy-server && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf4b39e483238cc31c74116806f9