### PR TITLE
chore(scripts): align ports and improve status checks

### DIFF
--- a/Implementation_Checklist_and_Status.md
+++ b/Implementation_Checklist_and_Status.md
@@ -127,3 +127,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Files: `tiling-services/catalog-api/server.ts`, `tiling-services/catalog-api/test/server.test.mjs`
   - Verification: `pnpm lint`, `pnpm test` — marked production ready.
 
+- [ ] 2025-08-30 — Startup/status script improvements
+  - Summary: Aligned Next.js dev port with config, added catalog API `/health` route, fixed proxy health check path, and made port checks tolerant of missing tools.
+  - Files: `apps/web/package.json`, `tiling-services/catalog-api/index.ts`, `status-atmosinsight.sh`, `start-atmosinsight.sh`, `stop-atmosinsight.sh`
+  - Verification: `pnpm status`, `pnpm stop` pass; `pnpm start` launches proxy and catalog but fails to confirm web app; `pnpm test` fails (proxy-server test).
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/start-atmosinsight.sh
+++ b/start-atmosinsight.sh
@@ -44,9 +44,9 @@ echo ""
 check_port() {
     local port=$1
     # Try multiple methods to check port usage
-    if lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if command -v lsof >/dev/null 2>&1 && lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
         return 0  # Port is in use
-    elif ss -tlnp | grep -q ":$port "; then
+    elif command -v ss >/dev/null 2>&1 && ss -tlnp | grep -q ":$port "; then
         return 0  # Port is in use (using ss)
     else
         return 1  # Port is free

--- a/status-atmosinsight.sh
+++ b/status-atmosinsight.sh
@@ -42,9 +42,9 @@ echo ""
 check_port() {
     local port=$1
     # Try multiple methods to check port usage
-    if lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if command -v lsof >/dev/null 2>&1 && lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
         return 0  # Port is in use
-    elif ss -tlnp | grep -q ":$port "; then
+    elif command -v ss >/dev/null 2>&1 && ss -tlnp | grep -q ":$port "; then
         return 0  # Port is in use (using ss)
     else
         return 1  # Port is free
@@ -80,7 +80,7 @@ echo -e "${BLUE}🔌 Proxy Server (Port $PROXY_PORT)${NC}"
 echo "----------------------------------------"
 
 if check_port $PROXY_PORT; then
-    local details=$(get_port_details $PROXY_PORT)
+    details=$(get_port_details $PROXY_PORT)
     IFS='|' read -r pid cmd user time <<< "$details"
     
     echo -e "${GREEN}✅ Status: RUNNING${NC}"
@@ -90,7 +90,7 @@ if check_port $PROXY_PORT; then
     echo -e "${BLUE}   Uptime:${NC} $time"
     
     # Check if it's responding
-    if curl -s http://localhost:$PROXY_PORT/health >/dev/null 2>&1; then
+    if curl -s http://localhost:$PROXY_PORT/api/healthz >/dev/null 2>&1; then
         echo -e "${GREEN}   Health: RESPONDING${NC}"
     else
         echo -e "${YELLOW}   Health: NOT RESPONDING${NC}"
@@ -107,7 +107,7 @@ echo -e "${BLUE}📚 Catalog API (Port $CATALOG_PORT)${NC}"
 echo "----------------------------------------"
 
 if check_port $CATALOG_PORT; then
-    local details=$(get_port_details $CATALOG_PORT)
+    details=$(get_port_details $CATALOG_PORT)
     IFS='|' read -r pid cmd user time <<< "$details"
     
     echo -e "${GREEN}✅ Status: RUNNING${NC}"
@@ -134,7 +134,7 @@ echo -e "${BLUE}📱 Next.js Web App (Port $WEB_PORT)${NC}"
 echo "----------------------------------------"
 
 if check_port $WEB_PORT; then
-    local details=$(get_port_details $WEB_PORT)
+    details=$(get_port_details $WEB_PORT)
     IFS='|' read -r pid cmd user time <<< "$details"
     
     echo -e "${GREEN}✅ Status: RUNNING${NC}"
@@ -165,9 +165,9 @@ PNPM_PROCESSES=$(pgrep -f "pnpm run dev" 2>/dev/null || true)
 if [ -n "$PNPM_PROCESSES" ]; then
     echo -e "${YELLOW}⚠️  Found additional pnpm processes:${NC}"
     echo "$PNPM_PROCESSES" | while read -r pid; do
-        local cmd=$(ps -p $pid -o comm= 2>/dev/null || echo "unknown")
-        local user=$(ps -p $pid -o user= 2>/dev/null || echo "unknown")
-        local time=$(ps -p $pid -o etime= 2>/dev/null || echo "unknown")
+        cmd=$(ps -p $pid -o comm= 2>/dev/null || echo "unknown")
+        user=$(ps -p $pid -o user= 2>/dev/null || echo "unknown")
+        time=$(ps -p $pid -o etime= 2>/dev/null || echo "unknown")
         echo -e "${BLUE}   PID $pid:${NC} $cmd (User: $user, Uptime: $time)"
     done
 else

--- a/tiling-services/catalog-api/index.ts
+++ b/tiling-services/catalog-api/index.ts
@@ -33,6 +33,14 @@ async function getTimes(id: string): Promise<string[]> {
 export async function handler(event: ServerEvent): Promise<ServerResponse> {
   const path = event.rawPath || '';
 
+  if (path === '/health') {
+    return {
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'ok' }),
+    };
+  }
+
   if (path === '/catalog/layers') {
     const layers = await getLayers();
     return {


### PR DESCRIPTION
## Summary
- align web dev script port with repo config
- expose simple /health endpoint for catalog API
- harden startup/status scripts for missing port tools and correct proxy health check

## Testing
- `pnpm lint`
- `pnpm test` (fails: proxy-server test)
- `pnpm status`
- `pnpm start` (proxy & catalog up, web app not confirmed)
- `pnpm stop`


------
https://chatgpt.com/codex/tasks/task_e_68b2e5b9386c8323bea52586bdbbbc0b