### PR TITLE
feat(providers): add SMHI Open Data provider

### DIFF
--- a/Implementation_Checklist_and_Status.md
+++ b/Implementation_Checklist_and_Status.md
@@ -152,3 +152,12 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Files: `packages/proxy-constants/*`, `proxy-server/src/app.ts`, `proxy-server/test/air.test.ts`, `proxy-server/.env.example`, `proxy-server/package.json`, `pnpm-lock.yaml`, `README.md`, `docs/features/open-weather-services.md`
   - Verification: `pnpm lint`, `pnpm test`, `pnpm --filter proxy-server test`
 
+- [x] 2025-08-30 — Initial provider modules for open weather APIs
+  - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
+  - Files: `packages/providers/*`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — SMHI Open Data provider module
+  - Summary: Implemented SMHI point forecast provider with URL builder and fetch helper; added tests, manifest entry, index export, and TypeScript config update for DOM/Node types.
+  - Files: `packages/providers/smhi.ts`, `packages/providers/test/smhi.test.ts`, `packages/providers/index.ts`, `packages/providers/tsconfig.json`, `providers.json`
+  - Verification: `pnpm lint`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -1,0 +1,5 @@
+export * as nws from './nws.js';
+export * as metno from './metno.js';
+export * as openmeteo from './openmeteo.js';
+export * as openweather from './openweather.js';
+export * as smhi from './smhi.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -1,0 +1,5 @@
+export * as nws from './nws.js';
+export * as metno from './metno.js';
+export * as openmeteo from './openmeteo.js';
+export * as openweather from './openweather.js';
+export * as smhi from './smhi.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,0 +1,5 @@
+export * as nws from './nws.js';
+export * as metno from './metno.js';
+export * as openmeteo from './openmeteo.js';
+export * as openweather from './openweather.js';
+export * as smhi from './smhi.js';

--- a/packages/providers/metno.d.ts
+++ b/packages/providers/metno.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "met-norway";
+export declare const baseUrl = "https://api.met.no/weatherapi";
+export interface Params {
+    lat: number;
+    lon: number;
+    format: 'compact' | 'complete';
+}
+export declare function buildRequest({ lat, lon, format }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/metno.js
+++ b/packages/providers/metno.js
@@ -1,0 +1,14 @@
+export const slug = 'met-norway';
+export const baseUrl = 'https://api.met.no/weatherapi';
+export function buildRequest({ lat, lon, format }) {
+    return `${baseUrl}/locationforecast/2.0/${format}?lat=${lat}&lon=${lon}`;
+}
+export async function fetchJson(url) {
+    const ua = process.env.METNO_USER_AGENT || process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+    const res = await fetch(url, {
+        headers: {
+            'User-Agent': ua,
+        },
+    });
+    return res.json();
+}

--- a/packages/providers/metno.ts
+++ b/packages/providers/metno.ts
@@ -1,0 +1,22 @@
+export const slug = 'met-norway';
+export const baseUrl = 'https://api.met.no/weatherapi';
+
+export interface Params {
+  lat: number;
+  lon: number;
+  format: 'compact' | 'complete';
+}
+
+export function buildRequest({ lat, lon, format }: Params): string {
+  return `${baseUrl}/locationforecast/2.0/${format}?lat=${lat}&lon=${lon}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const ua = process.env.METNO_USER_AGENT || process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': ua,
+    },
+  });
+  return res.json();
+}

--- a/packages/providers/nws.d.ts
+++ b/packages/providers/nws.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "nws-weather";
+export declare const baseUrl = "https://api.weather.gov";
+export interface Params {
+    lat: number;
+    lon: number;
+}
+export declare function buildRequest({ lat, lon }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/nws.js
+++ b/packages/providers/nws.js
@@ -1,0 +1,14 @@
+export const slug = 'nws-weather';
+export const baseUrl = 'https://api.weather.gov';
+export function buildRequest({ lat, lon }) {
+    return `${baseUrl}/points/${lat},${lon}`;
+}
+export async function fetchJson(url) {
+    const ua = process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+    const res = await fetch(url, {
+        headers: {
+            'User-Agent': ua,
+        },
+    });
+    return res.json();
+}

--- a/packages/providers/nws.ts
+++ b/packages/providers/nws.ts
@@ -1,0 +1,21 @@
+export const slug = 'nws-weather';
+export const baseUrl = 'https://api.weather.gov';
+
+export interface Params {
+  lat: number;
+  lon: number;
+}
+
+export function buildRequest({ lat, lon }: Params): string {
+  return `${baseUrl}/points/${lat},${lon}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const ua = process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': ua,
+    },
+  });
+  return res.json();
+}

--- a/packages/providers/openmeteo.d.ts
+++ b/packages/providers/openmeteo.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "open-meteo";
+export declare const baseUrl = "https://api.open-meteo.com";
+export interface Params {
+    latitude: number;
+    longitude: number;
+    hourly: string;
+}
+export declare function buildRequest({ latitude, longitude, hourly }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/openmeteo.js
+++ b/packages/providers/openmeteo.js
@@ -1,0 +1,9 @@
+export const slug = 'open-meteo';
+export const baseUrl = 'https://api.open-meteo.com';
+export function buildRequest({ latitude, longitude, hourly }) {
+    return `${baseUrl}/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=${encodeURIComponent(hourly)}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/openmeteo.ts
+++ b/packages/providers/openmeteo.ts
@@ -1,0 +1,17 @@
+export const slug = 'open-meteo';
+export const baseUrl = 'https://api.open-meteo.com';
+
+export interface Params {
+  latitude: number;
+  longitude: number;
+  hourly: string;
+}
+
+export function buildRequest({ latitude, longitude, hourly }: Params): string {
+  return `${baseUrl}/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=${encodeURIComponent(hourly)}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/openweather.d.ts
+++ b/packages/providers/openweather.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "openweather-onecall";
+export declare const baseUrl = "https://api.openweathermap.org";
+export interface Params {
+    lat: number;
+    lon: number;
+}
+export declare function buildRequest({ lat, lon }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/openweather.js
+++ b/packages/providers/openweather.js
@@ -1,0 +1,17 @@
+export const slug = 'openweather-onecall';
+export const baseUrl = 'https://api.openweathermap.org';
+export function buildRequest({ lat, lon }) {
+    const appid = process.env.OPENWEATHER_API_KEY;
+    if (!appid)
+        throw new Error('OPENWEATHER_API_KEY missing');
+    const params = new URLSearchParams({
+        lat: String(lat),
+        lon: String(lon),
+        appid,
+    });
+    return `${baseUrl}/data/3.0/onecall?${params.toString()}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/openweather.ts
+++ b/packages/providers/openweather.ts
@@ -1,0 +1,23 @@
+export const slug = 'openweather-onecall';
+export const baseUrl = 'https://api.openweathermap.org';
+
+export interface Params {
+  lat: number;
+  lon: number;
+}
+
+export function buildRequest({ lat, lon }: Params): string {
+  const appid = process.env.OPENWEATHER_API_KEY;
+  if (!appid) throw new Error('OPENWEATHER_API_KEY missing');
+  const params = new URLSearchParams({
+    lat: String(lat),
+    lon: String(lon),
+    appid,
+  });
+  return `${baseUrl}/data/3.0/onecall?${params.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@atmos/providers",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/providers/smhi.d.ts
+++ b/packages/providers/smhi.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "smhi-open-data";
+export declare const baseUrl = "https://opendata-download-metfcst.smhi.se/api";
+export interface Params {
+    lon: number;
+    lat: number;
+}
+export declare function buildRequest({ lon, lat }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/smhi.js
+++ b/packages/providers/smhi.js
@@ -1,0 +1,9 @@
+export const slug = 'smhi-open-data';
+export const baseUrl = 'https://opendata-download-metfcst.smhi.se/api';
+export function buildRequest({ lon, lat }) {
+    return `${baseUrl}/category/pmp3g/version/2/geotype/point/lon/${lon}/lat/${lat}/data.json`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/smhi.ts
+++ b/packages/providers/smhi.ts
@@ -1,0 +1,16 @@
+export const slug = 'smhi-open-data';
+export const baseUrl = 'https://opendata-download-metfcst.smhi.se/api';
+
+export interface Params {
+  lon: number;
+  lat: number;
+}
+
+export function buildRequest({ lon, lat }: Params): string {
+  return `${baseUrl}/category/pmp3g/version/2/geotype/point/lon/${lon}/lat/${lat}/data.json`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/test/metno.test.ts
+++ b/packages/providers/test/metno.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../metno.js';
+
+describe('met norway provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds locationforecast URL', () => {
+    const url = buildRequest({ lat: 59.91, lon: 10.75, format: 'compact' });
+    expect(url).toBe('https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=59.91&lon=10.75');
+  });
+
+  it('injects User-Agent header', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lat: 59.91, lon: 10.75, format: 'compact' });
+    await fetchJson(url);
+    const ua = process.env.METNO_USER_AGENT || process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+    expect(mock).toHaveBeenCalledWith(url, { headers: { 'User-Agent': ua } });
+  });
+});

--- a/packages/providers/test/nws.test.ts
+++ b/packages/providers/test/nws.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../nws.js';
+
+describe('nws provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds points URL', () => {
+    const url = buildRequest({ lat: 33.45, lon: -112.07 });
+    expect(url).toBe('https://api.weather.gov/points/33.45,-112.07');
+  });
+
+  it('injects User-Agent header', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lat: 33.45, lon: -112.07 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url, {
+      headers: { 'User-Agent': process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)' },
+    });
+  });
+});

--- a/packages/providers/test/openmeteo.test.ts
+++ b/packages/providers/test/openmeteo.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../openmeteo.js';
+
+describe('open-meteo provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds forecast URL', () => {
+    const url = buildRequest({ latitude: 1, longitude: 2, hourly: 'temperature_2m' });
+    expect(url).toBe('https://api.open-meteo.com/v1/forecast?latitude=1&longitude=2&hourly=temperature_2m');
+  });
+
+  it('calls fetch without headers', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ latitude: 1, longitude: 2, hourly: 'temperature_2m' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/test/openweather.test.ts
+++ b/packages/providers/test/openweather.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../openweather.js';
+
+describe('openweather provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds onecall URL', () => {
+    process.env.OPENWEATHER_API_KEY = 'test';
+    const url = buildRequest({ lat: 10, lon: 20 });
+    expect(url).toBe('https://api.openweathermap.org/data/3.0/onecall?lat=10&lon=20&appid=test');
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.OPENWEATHER_API_KEY = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lat: 10, lon: 20 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/test/smhi.test.ts
+++ b/packages/providers/test/smhi.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../smhi.js';
+
+describe('smhi provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds point forecast URL', () => {
+    const url = buildRequest({ lon: 18.06, lat: 59.33 });
+    expect(url).toBe('https://opendata-download-metfcst.smhi.se/api/category/pmp3g/version/2/geotype/point/lon/18.06/lat/59.33/data.json');
+  });
+
+  it('fetchJson uses no extra headers', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lon: 18.06, lat: 59.33 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"],
+    "declaration": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "test", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,18 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@20.19.11)(tsx@4.20.5)(yaml@2.8.1)
 
+  packages/providers:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.11
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.19.11)(tsx@4.20.5)(yaml@2.8.1)
+
   packages/proxy-constants:
     devDependencies:
       '@types/node':
@@ -8266,8 +8278,8 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       eslint: 9.34.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0))(eslint@9.34.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.34.0)
       eslint-plugin-react: 7.37.5(eslint@9.34.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.34.0)
@@ -8286,7 +8298,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -8297,22 +8309,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0))(eslint@9.34.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0))(eslint@9.34.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       eslint: 9.34.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0))(eslint@9.34.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8323,7 +8335,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0))(eslint@9.34.0))(eslint@9.34.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/providers.json
+++ b/providers.json
@@ -1,0 +1,7 @@
+[
+  {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
+  {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
+  {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "smhi-open-data", "category": "weather", "accessRoute": "REST", "baseUrl": "https://opendata-download-metfcst.smhi.se/api"}
+]


### PR DESCRIPTION
## Summary
- add SMHI Open Data point forecast provider module
- include SMHI in provider manifest and exports
- document provider addition in implementation log

## Testing
- `pnpm lint`
- `pnpm --filter @atmos/providers test`
- `pnpm test` *(fails: missing `nock` in proxy-server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a29e9808323b6052416db88a71b