### PR TITLE
feat(providers): add eccc geomet tile provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,7 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+- [x] 2025-08-30 — ECCC GeoMet tile provider
+  - Summary: Added canonical OGC KVP/WMTS request builder and tile fetcher with tests.
+  - Files: `packages/providers/eccc.ts`, `packages/providers/test/eccc.test.ts`, `packages/providers/index.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/eccc.d.ts
+++ b/packages/providers/eccc.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "eccc-geomet";
+export declare const baseUrl = "https://geo.weather.gc.ca/geomet";
+export interface Params {
+    urlTemplate?: string;
+    [key: string]: any;
+}
+export declare function buildRequest(params: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/eccc.js
+++ b/packages/providers/eccc.js
@@ -1,0 +1,35 @@
+export const slug = 'eccc-geomet';
+export const baseUrl = 'https://geo.weather.gc.ca/geomet';
+export function buildRequest(params) {
+    const { urlTemplate, ...rest } = params;
+    if (urlTemplate) {
+        let path = urlTemplate.replace(/\{(\w+)\}/g, (_match, key) => {
+            if (!(key in rest))
+                throw new Error(`Missing parameter ${key}`);
+            return encodeURIComponent(rest[key]);
+        });
+        return `${baseUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+    }
+    const keys = Object.keys(rest).sort();
+    const search = new URLSearchParams();
+    for (const key of keys) {
+        const value = rest[key];
+        if (value === undefined || value === null)
+            continue;
+        if (Array.isArray(value)) {
+            search.set(key, value.join(','));
+        }
+        else {
+            search.set(key, String(value));
+        }
+    }
+    const query = search
+        .toString()
+        .replace(/%3A/g, ':')
+        .replace(/%2C/g, ',');
+    return query ? `${baseUrl}?${query}` : baseUrl;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/eccc.ts
+++ b/packages/providers/eccc.ts
@@ -1,0 +1,39 @@
+export const slug = 'eccc-geomet';
+export const baseUrl = 'https://geo.weather.gc.ca/geomet';
+
+export interface Params {
+  urlTemplate?: string;
+  [key: string]: any;
+}
+
+export function buildRequest(params: Params): string {
+  const { urlTemplate, ...rest } = params;
+  if (urlTemplate) {
+    let path = urlTemplate.replace(/\{(\w+)\}/g, (_match, key) => {
+      if (!(key in rest)) throw new Error(`Missing parameter ${key}`);
+      return encodeURIComponent(rest[key]);
+    });
+    return `${baseUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+  }
+  const keys = Object.keys(rest).sort();
+  const search = new URLSearchParams();
+  for (const key of keys) {
+    const value = rest[key];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      search.set(key, value.join(','));
+    } else {
+      search.set(key, String(value));
+    }
+  }
+  const query = search
+    .toString()
+    .replace(/%3A/g, ':')
+    .replace(/%2C/g, ',');
+  return query ? `${baseUrl}?${query}` : baseUrl;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as eccc from './eccc.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as eccc from './eccc.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as eccc from './eccc.js';

--- a/packages/providers/test/eccc.test.ts
+++ b/packages/providers/test/eccc.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequest } from '../eccc.js';
+
+describe('eccc geomet provider', () => {
+  it('canonicalizes query parameters', () => {
+    const url = buildRequest({
+      request: 'GetMap',
+      service: 'WMS',
+      layers: 'RDPS.CONUS_T',
+      crs: 'EPSG:4326',
+      bbox: [0, 0, 1, 1],
+    });
+    expect(url).toBe(
+      'https://geo.weather.gc.ca/geomet?bbox=0,0,1,1&crs=EPSG:4326&layers=RDPS.CONUS_T&request=GetMap&service=WMS'
+    );
+  });
+
+  it('builds wmts REST path', () => {
+    const url = buildRequest({
+      urlTemplate: 'wmts/1.0.0/{layer}/{style}/{tileMatrixSet}/{tileMatrix}/{tileRow}/{tileCol}.png',
+      layer: 'RDPS.CONUS_T',
+      style: 'default',
+      tileMatrixSet: 'EPSG4326',
+      tileMatrix: 0,
+      tileRow: 1,
+      tileCol: 2,
+    });
+    expect(url).toBe(
+      'https://geo.weather.gc.ca/geomet/wmts/1.0.0/RDPS.CONUS_T/default/EPSG4326/0/1/2.png'
+    );
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "eccc-geomet", "category": "weather", "accessRoute": "OGC", "baseUrl": "https://geo.weather.gc.ca/geomet"}
 ]


### PR DESCRIPTION
## Summary
- add `eccc-geomet` provider for Environment Canada GeoMet tiles
- support canonical OGC KVP and WMTS REST template requests
- document provider in manifest and implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348b160508323b5faf7b4e5f5a9e9