### PR TITLE
feat(providers): add DWD OpenData provider with KVP builder

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — DWD OpenData provider with KVP builder
+  - Summary: Added DWD module with WMS/WFS KVP parameter builder, binary tile fetch helper, manifest entry, and index exports.
+  - Files: `packages/providers/dwd.ts`, `packages/providers/index.ts`, `packages/providers/test/dwd.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.

--- a/packages/providers/dwd.d.ts
+++ b/packages/providers/dwd.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "dwd-opendata";
+export declare const baseUrl = "https://opendata.dwd.de";
+export interface KvpParams {
+    [key: string]: string | number | boolean;
+}
+export declare function buildKvp(params: KvpParams): string;
+export declare function buildWmsParams(params: KvpParams): string;
+export declare function buildWfsParams(params: KvpParams): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/dwd.js
+++ b/packages/providers/dwd.js
@@ -1,0 +1,19 @@
+export const slug = 'dwd-opendata';
+export const baseUrl = 'https://opendata.dwd.de';
+export function buildKvp(params) {
+    return Object.entries(params)
+        .map(([k, v]) => [k.toUpperCase(), String(v)])
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+        .join('&');
+}
+export function buildWmsParams(params) {
+    return buildKvp(params);
+}
+export function buildWfsParams(params) {
+    return buildKvp(params);
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/dwd.ts
+++ b/packages/providers/dwd.ts
@@ -1,0 +1,27 @@
+export const slug = 'dwd-opendata';
+export const baseUrl = 'https://opendata.dwd.de';
+
+export interface KvpParams {
+  [key: string]: string | number | boolean;
+}
+
+export function buildKvp(params: KvpParams): string {
+  return Object.entries(params)
+    .map(([k, v]) => [k.toUpperCase(), String(v)] as [string, string])
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+export function buildWmsParams(params: KvpParams): string {
+  return buildKvp(params);
+}
+
+export function buildWfsParams(params: KvpParams): string {
+  return buildKvp(params);
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as dwd from './dwd.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as dwd from './dwd.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as dwd from './dwd.js';

--- a/packages/providers/test/dwd.test.ts
+++ b/packages/providers/test/dwd.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildWmsParams, buildWfsParams, fetchTile } from '../dwd.js';
+
+describe('dwd-opendata provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds WMS params in sorted uppercase order', () => {
+    const params = buildWmsParams({ version: '1.3.0', service: 'WMS', request: 'GetMap' });
+    expect(params).toBe('REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0');
+  });
+
+  it('builds WFS params in sorted uppercase order', () => {
+    const params = buildWfsParams({ request: 'GetFeature', service: 'WFS', version: '2.0.0' });
+    expect(params).toBe('REQUEST=GetFeature&SERVICE=WFS&VERSION=2.0.0');
+  });
+
+  it('fetches binary tile', async () => {
+    const mockBuffer = new ArrayBuffer(2);
+    const mock = vi.fn().mockResolvedValue({ arrayBuffer: () => Promise.resolve(mockBuffer) });
+    // @ts-ignore
+    global.fetch = mock;
+    const buf = await fetchTile('https://example.com/tile');
+    expect(mock).toHaveBeenCalledWith('https://example.com/tile');
+    expect(buf).toBeInstanceOf(ArrayBuffer);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "dwd-opendata", "category": "weather", "accessRoute": "WMS/WFS", "baseUrl": "https://opendata.dwd.de"}
 ]


### PR DESCRIPTION
## Summary
- add DWD OpenData provider with WMS/WFS key-value parameter builder
- support binary tile fetches via new `fetchTile` helper
- cover parameter capitalization and ordering with golden tests

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm test` *(fails: proxy-server test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b348b18ebc8323a089730703f4538a