### PR TITLE
feat(providers): add fmi open data provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — FMI Open Data provider module
+  - Summary: Added `fmi-open-data` provider with stored query builder, tile fetcher, tests, and manifest entry.
+  - Files: `packages/providers/fmi.ts`, `packages/providers/fmi.js`, `packages/providers/fmi.d.ts`, `packages/providers/index.ts`, `packages/providers/index.js`, `packages/providers/index.d.ts`, `packages/providers/test/fmi.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`

--- a/packages/providers/fmi.d.ts
+++ b/packages/providers/fmi.d.ts
@@ -1,0 +1,14 @@
+export declare const slug = "fmi-open-data";
+export declare const baseUrl = "https://opendata.fmi.fi";
+export interface BaseParams {
+    storedquery_id: string;
+}
+export interface LatLonParams extends BaseParams {
+    latlon: [number, number];
+}
+export interface BBoxParams extends BaseParams {
+    bbox: [number, number, number, number];
+}
+export type Params = LatLonParams | BBoxParams;
+export declare function buildRequest(params: Params): string;
+export declare function fetchTile(url: string): Promise<any>;

--- a/packages/providers/fmi.js
+++ b/packages/providers/fmi.js
@@ -1,0 +1,25 @@
+export const slug = 'fmi-open-data';
+export const baseUrl = 'https://opendata.fmi.fi';
+export function buildRequest(params) {
+    const parts = [
+        'service=WFS',
+        'request=getFeature',
+        `storedquery_id=${params.storedquery_id}`,
+    ];
+    if ('latlon' in params) {
+        const [lat, lon] = params.latlon;
+        parts.push(`latlon=${lat},${lon}`);
+    }
+    else {
+        parts.push(`bbox=${params.bbox.join(',')}`);
+    }
+    return `${baseUrl}/wfs?${parts.join('&')}`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    const type = res.headers.get('content-type') ?? '';
+    if (type.includes('json')) {
+        return res.json();
+    }
+    return res.arrayBuffer();
+}

--- a/packages/providers/fmi.ts
+++ b/packages/providers/fmi.ts
@@ -1,0 +1,40 @@
+export const slug = 'fmi-open-data';
+export const baseUrl = 'https://opendata.fmi.fi';
+
+export interface BaseParams {
+  storedquery_id: string;
+}
+
+export interface LatLonParams extends BaseParams {
+  latlon: [number, number];
+}
+
+export interface BBoxParams extends BaseParams {
+  bbox: [number, number, number, number];
+}
+
+export type Params = LatLonParams | BBoxParams;
+
+export function buildRequest(params: Params): string {
+  const parts = [
+    'service=WFS',
+    'request=getFeature',
+    `storedquery_id=${params.storedquery_id}`,
+  ];
+  if ('latlon' in params) {
+    const [lat, lon] = params.latlon;
+    parts.push(`latlon=${lat},${lon}`);
+  } else {
+    parts.push(`bbox=${params.bbox.join(',')}`);
+  }
+  return `${baseUrl}/wfs?${parts.join('&')}`;
+}
+
+export async function fetchTile(url: string): Promise<any> {
+  const res = await fetch(url);
+  const type = res.headers.get('content-type') ?? '';
+  if (type.includes('json')) {
+    return res.json();
+  }
+  return res.arrayBuffer();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as fmi from './fmi.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as fmi from './fmi.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as fmi from './fmi.js';

--- a/packages/providers/test/fmi.test.ts
+++ b/packages/providers/test/fmi.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequest } from '../fmi.js';
+
+describe('fmi-open-data provider', () => {
+  it('builds stored query URL with latlon', () => {
+    const url = buildRequest({
+      storedquery_id: 'fmi::forecast::weather::point::simple',
+      latlon: [60, 25],
+    });
+    expect(url).toBe(
+      'https://opendata.fmi.fi/wfs?service=WFS&request=getFeature&storedquery_id=fmi::forecast::weather::point::simple&latlon=60,25'
+    );
+  });
+
+  it('builds stored query URL with bbox', () => {
+    const url = buildRequest({
+      storedquery_id: 'test',
+      bbox: [1, 2, 3, 4],
+    });
+    expect(url).toBe(
+      'https://opendata.fmi.fi/wfs?service=WFS&request=getFeature&storedquery_id=test&bbox=1,2,3,4'
+    );
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "fmi-open-data", "category": "weather", "accessRoute": "REST", "baseUrl": "https://opendata.fmi.fi"}
 ]


### PR DESCRIPTION
## Summary
- add fmi-open-data provider with stored query URL builder and tile fetcher
- expose fmi provider in manifest and package index
- document change in implementation log

## Testing
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348b241a483239c90b13d8f14235a