### PR TITLE
feat(provider): add Apple WeatherKit module

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -257,6 +257,10 @@ Implementation note: A high-quality Python FastAPI microservice (`tiling-service
 - `NWS_USER_AGENT` — e.g., `(Vortexa, email@domain)` per NWS requirement. citeturn0search0turn0search3
 - `RAINVIEWER_ENABLED` — Gate RainViewer integration.
 - `GIBS_ENABLED` — Gate GIBS integration.
+- `WEATHERKIT_TEAM_ID` — Apple Developer team identifier for signing.
+- `WEATHERKIT_SERVICE_ID` — WeatherKit service identifier.
+- `WEATHERKIT_KEY_ID` — Key ID for the WeatherKit private key.
+- `WEATHERKIT_PRIVATE_KEY` — PEM-formatted key used for JWT signing.
 - Mapbox/Cesium tokens as required by your chosen basemap providers.
 
 ---

--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — Add Apple WeatherKit provider
+  - Summary: Implemented WeatherKit module with JWT auth and documented required env vars.
+  - Files: `packages/providers/weatherkit.ts`, `packages/providers/index.ts`, `providers.json`, `docs/README.md`, `docs/AGENTS.md`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,10 @@ This commit establishes Milestone M1: foundational infrastructure configuration 
 - `OWM_API_KEY` – OpenWeatherMap tile API key used by the proxy.
 - `RAINVIEWER_ENABLED` – `true|false` to enable/disable RainViewer proxy (default enabled).
 - `GIBS_ENABLED` – `true|false` to enable/disable GIBS proxy (if implemented).
+- `WEATHERKIT_TEAM_ID` – Apple Developer team ID for WeatherKit JWTs.
+- `WEATHERKIT_SERVICE_ID` – WeatherKit service identifier.
+- `WEATHERKIT_KEY_ID` – Key ID associated with the WeatherKit private key.
+- `WEATHERKIT_PRIVATE_KEY` – PEM contents used to sign WeatherKit JWTs.
 - Mapbox/Cesium tokens as required by your chosen basemap providers.
 - `GLM_TOE_ENABLED` – `true|false` to enable experimental GLM TOE tile endpoint.
 - `GLM_TOE_PY_URL` – If set, proxy `/api/glm-toe/:z/:x/:y.png` to the Python FastAPI service (`tiling-services/glm_toe`).

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as weatherkit from './weatherkit.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as weatherkit from './weatherkit.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as weatherkit from './weatherkit.js';

--- a/packages/providers/test/weatherkit.test.ts
+++ b/packages/providers/test/weatherkit.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as weatherkit from '../weatherkit.js';
+
+const { buildRequest, fetchJson } = weatherkit;
+
+describe('weatherkit provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds weather URL', () => {
+    const url = buildRequest({
+      lang: 'en',
+      lat: 10,
+      lon: 20,
+      dataSets: ['currentWeather', 'forecastDaily'],
+    });
+    expect(url).toBe(
+      'https://weatherkit.apple.com/api/v1/weather/en/10/20?dataSets=currentWeather,forecastDaily'
+    );
+  });
+
+  it('injects Authorization header', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mockFetch;
+    const url = buildRequest({
+      lang: 'en',
+      lat: 10,
+      lon: 20,
+      dataSets: ['currentWeather'],
+    });
+    await fetchJson(url, 'mock');
+    expect(mockFetch).toHaveBeenCalledWith(url, {
+      headers: { Authorization: 'Bearer mock' },
+    });
+  });
+});

--- a/packages/providers/weatherkit.d.ts
+++ b/packages/providers/weatherkit.d.ts
@@ -1,0 +1,11 @@
+export declare const slug = "apple-weatherkit";
+export declare const baseUrl = "https://weatherkit.apple.com/api/v1/weather";
+export interface Params {
+    lang: string;
+    lat: number;
+    lon: number;
+    dataSets: string[];
+}
+export declare function buildRequest({ lang, lat, lon, dataSets }: Params): string;
+export declare let generateJwt: () => string;
+export declare function fetchJson(url: string, token?: string): Promise<any>;

--- a/packages/providers/weatherkit.js
+++ b/packages/providers/weatherkit.js
@@ -1,0 +1,35 @@
+import { createSign } from 'crypto';
+export const slug = 'apple-weatherkit';
+export const baseUrl = 'https://weatherkit.apple.com/api/v1/weather';
+export function buildRequest({ lang, lat, lon, dataSets }) {
+    const params = `dataSets=${dataSets.join(',')}`;
+    return `${baseUrl}/${lang}/${lat}/${lon}?${params}`;
+}
+export let generateJwt = () => {
+    const teamId = process.env.WEATHERKIT_TEAM_ID;
+    const serviceId = process.env.WEATHERKIT_SERVICE_ID;
+    const keyId = process.env.WEATHERKIT_KEY_ID;
+    const privateKey = process.env.WEATHERKIT_PRIVATE_KEY;
+    if (!teamId || !serviceId || !keyId || !privateKey) {
+        throw new Error('WeatherKit env vars missing');
+    }
+    const header = Buffer.from(JSON.stringify({ alg: 'ES256', kid: keyId })).toString('base64url');
+    const iat = Math.floor(Date.now() / 1000);
+    const payload = Buffer.from(JSON.stringify({ iss: teamId, sub: serviceId, iat, exp: iat + 3600 })).toString('base64url');
+    const body = `${header}.${payload}`;
+    const signer = createSign('sha256');
+    signer.update(body);
+    signer.end();
+    const signature = signer
+        .sign(privateKey.replace(/\\n/g, '\n'))
+        .toString('base64url');
+    return `${body}.${signature}`;
+};
+export async function fetchJson(url, token = generateJwt()) {
+    const res = await fetch(url, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return res.json();
+}

--- a/packages/providers/weatherkit.ts
+++ b/packages/providers/weatherkit.ts
@@ -1,0 +1,53 @@
+import { createSign } from 'crypto';
+
+export const slug = 'apple-weatherkit';
+export const baseUrl = 'https://weatherkit.apple.com/api/v1/weather';
+
+export interface Params {
+  lang: string;
+  lat: number;
+  lon: number;
+  dataSets: string[];
+}
+
+export function buildRequest({ lang, lat, lon, dataSets }: Params): string {
+  const params = `dataSets=${dataSets.join(',')}`;
+  return `${baseUrl}/${lang}/${lat}/${lon}?${params}`;
+}
+
+export let generateJwt = (): string => {
+  const teamId = process.env.WEATHERKIT_TEAM_ID;
+  const serviceId = process.env.WEATHERKIT_SERVICE_ID;
+  const keyId = process.env.WEATHERKIT_KEY_ID;
+  const privateKey = process.env.WEATHERKIT_PRIVATE_KEY;
+  if (!teamId || !serviceId || !keyId || !privateKey) {
+    throw new Error('WeatherKit env vars missing');
+  }
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'ES256', kid: keyId })
+  ).toString('base64url');
+  const iat = Math.floor(Date.now() / 1000);
+  const payload = Buffer.from(
+    JSON.stringify({ iss: teamId, sub: serviceId, iat, exp: iat + 3600 })
+  ).toString('base64url');
+  const body = `${header}.${payload}`;
+  const signer = createSign('sha256');
+  signer.update(body);
+  signer.end();
+  const signature = signer
+    .sign(privateKey.replace(/\\n/g, '\n'))
+    .toString('base64url');
+  return `${body}.${signature}`;
+};
+
+export async function fetchJson(
+  url: string,
+  token: string = generateJwt()
+): Promise<any> {
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -1,6 +1,32 @@
 [
-  {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
-  {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
-  {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {
+    "slug": "nws-weather",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.weather.gov"
+  },
+  {
+    "slug": "met-norway",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.met.no/weatherapi"
+  },
+  {
+    "slug": "open-meteo",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.open-meteo.com"
+  },
+  {
+    "slug": "openweather-onecall",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.openweathermap.org"
+  },
+  {
+    "slug": "apple-weatherkit",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://weatherkit.apple.com/api/v1/weather"
+  }
 ]


### PR DESCRIPTION
## Summary
- add Apple WeatherKit provider with JWT auth
- export provider in registry and manifest
- document WeatherKit environment variables

## Testing
- `pnpm --filter @atmos/providers test`
- `pnpm --filter @atmos/providers build`
- `pnpm lint` *(fails: Unexpected any in apps/web/src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b348b42d1c83239440b062e481f122