### PR TITLE
feat(providers): add uk met datahub provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,7 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+- [x] 2025-08-30 — UK Met Office DataHub provider
+  - Summary: Added `ukmet-datahub` module with request builder, API key header, tests, and manifest update.
+  - Files: `packages/providers/ukmet.ts`, `packages/providers/index.ts`, `packages/providers/test/ukmet.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as ukmet from './ukmet.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as ukmet from './ukmet.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as ukmet from './ukmet.js';

--- a/packages/providers/test/ukmet.test.ts
+++ b/packages/providers/test/ukmet.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../ukmet.js';
+
+describe('ukmet provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (global as any).fetch;
+  });
+
+  it('builds point forecast URL', () => {
+    const url = buildRequest({ path: '/point/forecast', latitude: 51.5, longitude: -0.1 });
+    expect(url).toBe('https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/point/forecast?latitude=51.5&longitude=-0.1');
+  });
+
+  it('adds apikey header', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    (global as any).fetch = mock;
+    process.env.UKMET_API_KEY = 'abc';
+    const url = buildRequest({ path: '/point/forecast', latitude: 51.5, longitude: -0.1 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url, {
+      headers: { apikey: 'abc' },
+    });
+  });
+});

--- a/packages/providers/ukmet.d.ts
+++ b/packages/providers/ukmet.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "ukmet-datahub";
+export declare const baseUrl = "https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0";
+export interface Params {
+    path: string;
+    [key: string]: string | number;
+}
+export declare function buildRequest({ path, ...query }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/ukmet.js
+++ b/packages/providers/ukmet.js
@@ -1,0 +1,17 @@
+export const slug = 'ukmet-datahub';
+export const baseUrl = 'https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0';
+export function buildRequest({ path, ...query }) {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(query)) {
+        params.append(k, String(v));
+    }
+    return `${baseUrl}${path}?${params.toString()}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url, {
+        headers: {
+            apikey: process.env.UKMET_API_KEY,
+        },
+    });
+    return res.json();
+}

--- a/packages/providers/ukmet.ts
+++ b/packages/providers/ukmet.ts
@@ -1,0 +1,24 @@
+export const slug = 'ukmet-datahub';
+export const baseUrl = 'https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0';
+
+export interface Params {
+  path: string;
+  [key: string]: string | number;
+}
+
+export function buildRequest({ path, ...query }: Params): string {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(query)) {
+    params.append(k, String(v));
+  }
+  return `${baseUrl}${path}?${params.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url, {
+    headers: {
+      apikey: process.env.UKMET_API_KEY as string,
+    },
+  });
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "ukmet-datahub", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0"}
 ]


### PR DESCRIPTION
## Summary
- add ukmet-datahub provider with API key header
- include provider in manifest and exports
- document change in implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348b63e6883239e3396874a88faee