### PR TITLE
feat(providers): add Tomorrow.io provider

### DIFF
--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as tomorrowio from './tomorrowio.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as tomorrowio from './tomorrowio.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as tomorrowio from './tomorrowio.js';

--- a/packages/providers/test/tomorrowio.test.ts
+++ b/packages/providers/test/tomorrowio.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../tomorrowio.js';
+
+describe('tomorrowio provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds forecast URL', () => {
+    const url = buildRequest({ location: '12.3,45.6', fields: 'temperature,precipitation', timesteps: 'hourly' });
+    expect(url).toBe('https://api.tomorrow.io/v4/weather/forecast?location=12.3%2C45.6&fields=temperature%2Cprecipitation&timesteps=hourly');
+  });
+
+  it('injects apikey header', async () => {
+    process.env.TOMORROW_API_KEY = 'test-key';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ location: '12.3,45.6', fields: 'temperature,precipitation', timesteps: 'hourly' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url, { headers: { apikey: 'test-key' } });
+  });
+});

--- a/packages/providers/tomorrowio.d.ts
+++ b/packages/providers/tomorrowio.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "tomorrowio-v4";
+export declare const baseUrl = "https://api.tomorrow.io/v4";
+export interface Params {
+    location: string;
+    fields: string;
+    timesteps: string;
+}
+export declare function buildRequest({ location, fields, timesteps }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/tomorrowio.js
+++ b/packages/providers/tomorrowio.js
@@ -1,0 +1,16 @@
+export const slug = 'tomorrowio-v4';
+export const baseUrl = 'https://api.tomorrow.io/v4';
+export function buildRequest({ location, fields, timesteps }) {
+    return `${baseUrl}/weather/forecast?location=${encodeURIComponent(location)}&fields=${encodeURIComponent(fields)}&timesteps=${encodeURIComponent(timesteps)}`;
+}
+export async function fetchJson(url) {
+    const apikey = process.env.TOMORROW_API_KEY;
+    if (!apikey)
+        throw new Error('TOMORROW_API_KEY missing');
+    const res = await fetch(url, {
+        headers: {
+            apikey,
+        },
+    });
+    return res.json();
+}

--- a/packages/providers/tomorrowio.ts
+++ b/packages/providers/tomorrowio.ts
@@ -1,0 +1,23 @@
+export const slug = 'tomorrowio-v4';
+export const baseUrl = 'https://api.tomorrow.io/v4';
+
+export interface Params {
+  location: string;
+  fields: string;
+  timesteps: string;
+}
+
+export function buildRequest({ location, fields, timesteps }: Params): string {
+  return `${baseUrl}/weather/forecast?location=${encodeURIComponent(location)}&fields=${encodeURIComponent(fields)}&timesteps=${encodeURIComponent(timesteps)}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const apikey = process.env.TOMORROW_API_KEY;
+  if (!apikey) throw new Error('TOMORROW_API_KEY missing');
+  const res = await fetch(url, {
+    headers: {
+      apikey,
+    },
+  });
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "tomorrowio-v4", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.tomorrow.io/v4"}
 ]


### PR DESCRIPTION
## Summary
- add Tomorrow.io provider with forecast builder and apikey header
- expose provider in index and manifest
- test URL construction and header injection

## Testing
- `pnpm -F providers build`
- `pnpm -F providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348b6fd348323bde123d45ff46c5b