### PR TITLE
feat(providers): add weatherbit provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — Weatherbit provider module
+  - Summary: Added Weatherbit provider with request builder and tests; updated provider index and manifest.
+  - Files: `packages/providers/weatherbit.ts`, `packages/providers/test/weatherbit.test.ts`, `packages/providers/index.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as weatherbit from './weatherbit.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as weatherbit from './weatherbit.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as weatherbit from './weatherbit.js';

--- a/packages/providers/test/weatherbit.test.ts
+++ b/packages/providers/test/weatherbit.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../weatherbit.js';
+
+describe('weatherbit provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds endpoint URL', () => {
+    process.env.WEATHERBIT_API_KEY = 'test';
+    const url = buildRequest({ endpoint: 'current', lat: 10, lon: 20 });
+    expect(url).toBe(
+      'https://api.weatherbit.io/v2.0/current?lat=10&lon=20&key=test'
+    );
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.WEATHERBIT_API_KEY = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ endpoint: 'current', lat: 10, lon: 20 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/weatherbit.d.ts
+++ b/packages/providers/weatherbit.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "weatherbit";
+export declare const baseUrl = "https://api.weatherbit.io";
+export interface Params {
+    endpoint: string;
+    lat: number;
+    lon: number;
+}
+export declare function buildRequest({ endpoint, lat, lon }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/weatherbit.js
+++ b/packages/providers/weatherbit.js
@@ -1,0 +1,17 @@
+export const slug = 'weatherbit';
+export const baseUrl = 'https://api.weatherbit.io';
+export function buildRequest({ endpoint, lat, lon }) {
+    const key = process.env.WEATHERBIT_API_KEY;
+    if (!key)
+        throw new Error('WEATHERBIT_API_KEY missing');
+    const params = new URLSearchParams({
+        lat: String(lat),
+        lon: String(lon),
+        key,
+    });
+    return `${baseUrl}/v2.0/${endpoint}?${params.toString()}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/weatherbit.ts
+++ b/packages/providers/weatherbit.ts
@@ -1,0 +1,24 @@
+export const slug = 'weatherbit';
+export const baseUrl = 'https://api.weatherbit.io';
+
+export interface Params {
+  endpoint: string;
+  lat: number;
+  lon: number;
+}
+
+export function buildRequest({ endpoint, lat, lon }: Params): string {
+  const key = process.env.WEATHERBIT_API_KEY;
+  if (!key) throw new Error('WEATHERBIT_API_KEY missing');
+  const params = new URLSearchParams({
+    lat: String(lat),
+    lon: String(lon),
+    key,
+  });
+  return `${baseUrl}/v2.0/${endpoint}?${params.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -1,6 +1,32 @@
 [
-  {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
-  {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
-  {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {
+    "slug": "nws-weather",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.weather.gov"
+  },
+  {
+    "slug": "met-norway",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.met.no/weatherapi"
+  },
+  {
+    "slug": "open-meteo",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.open-meteo.com"
+  },
+  {
+    "slug": "openweather-onecall",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.openweathermap.org"
+  },
+  {
+    "slug": "weatherbit",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.weatherbit.io"
+  }
 ]


### PR DESCRIPTION
## Summary
- add Weatherbit provider module and tests
- export Weatherbit in providers index and update manifest
- log Weatherbit addition in implementation checklist

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348b857c88323b127ad25ef398ea6