### PR TITLE
feat: add xweather provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — XWeather provider module
+  - Summary: Added XWeather provider using Aeris API with client credentials and canonical query ordering.
+  - Files: `packages/providers/xweather.ts`, `packages/providers/xweather.js`, `packages/providers/xweather.d.ts`, `packages/providers/index.ts`, `packages/providers/index.js`, `packages/providers/index.d.ts`, `packages/providers/test/xweather.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as xweather from './xweather.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as xweather from './xweather.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as xweather from './xweather.js';

--- a/packages/providers/test/xweather.test.ts
+++ b/packages/providers/test/xweather.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../xweather.js';
+
+describe('xweather provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.XWEATHER_CLIENT_ID;
+    delete process.env.XWEATHER_CLIENT_SECRET;
+  });
+
+  it('builds URL with canonical query ordering and auth', () => {
+    process.env.XWEATHER_CLIENT_ID = 'id';
+    process.env.XWEATHER_CLIENT_SECRET = 'secret';
+    const url = buildRequest({
+      endpoint: 'observations',
+      params: { c: '3', a: '1', b: '2' },
+    });
+    expect(url).toBe(
+      'https://api.aerisapi.com/observations?a=1&b=2&c=3&client_id=id&client_secret=secret'
+    );
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.XWEATHER_CLIENT_ID = 'id';
+    process.env.XWEATHER_CLIENT_SECRET = 'secret';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ endpoint: 'observations', params: {} });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/xweather.d.ts
+++ b/packages/providers/xweather.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "xweather";
+export declare const baseUrl = "https://api.aerisapi.com";
+export interface BuildRequestOptions {
+    endpoint: string;
+    params: Record<string, string>;
+}
+export declare function buildRequest({ endpoint, params }: BuildRequestOptions): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/xweather.js
+++ b/packages/providers/xweather.js
@@ -1,0 +1,22 @@
+export const slug = 'xweather';
+export const baseUrl = 'https://api.aerisapi.com';
+export function buildRequest({ endpoint, params }) {
+  const clientId = process.env.XWEATHER_CLIENT_ID;
+  if (!clientId)
+    throw new Error('XWEATHER_CLIENT_ID missing');
+  const clientSecret = process.env.XWEATHER_CLIENT_SECRET;
+  if (!clientSecret)
+    throw new Error('XWEATHER_CLIENT_SECRET missing');
+  const merged = { ...params, client_id: clientId, client_secret: clientSecret };
+  const searchParams = new URLSearchParams();
+  Object.keys(merged)
+    .sort()
+    .forEach((key) => {
+      searchParams.append(key, merged[key]);
+    });
+  return `${baseUrl}/${endpoint}?${searchParams.toString()}`;
+}
+export async function fetchJson(url) {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/xweather.ts
+++ b/packages/providers/xweather.ts
@@ -1,0 +1,27 @@
+export const slug = 'xweather';
+export const baseUrl = 'https://api.aerisapi.com';
+
+export interface BuildRequestOptions {
+  endpoint: string;
+  params: Record<string, string>;
+}
+
+export function buildRequest({ endpoint, params }: BuildRequestOptions): string {
+  const clientId = process.env.XWEATHER_CLIENT_ID;
+  if (!clientId) throw new Error('XWEATHER_CLIENT_ID missing');
+  const clientSecret = process.env.XWEATHER_CLIENT_SECRET;
+  if (!clientSecret) throw new Error('XWEATHER_CLIENT_SECRET missing');
+  const merged = { ...params, client_id: clientId, client_secret: clientSecret };
+  const searchParams = new URLSearchParams();
+  Object.keys(merged)
+    .sort()
+    .forEach((key) => {
+      searchParams.append(key, merged[key]);
+    });
+  return `${baseUrl}/${endpoint}?${searchParams.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "xweather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.aerisapi.com"}
 ]


### PR DESCRIPTION
## Summary
- add xweather provider for Aeris API with canonical query building
- document new provider in manifest, index and implementation log
- verify provider request construction and fetch

## Testing
- `pnpm --filter @atmos/providers test`

------
https://chatgpt.com/codex/tasks/task_e_68b348b928b08323a07fc12d6d12f577