### PR TITLE
feat: add visual crossing provider

### DIFF
--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as visualcrossing from './visualcrossing.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as visualcrossing from './visualcrossing.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as visualcrossing from './visualcrossing.js';

--- a/packages/providers/test/visualcrossing.test.ts
+++ b/packages/providers/test/visualcrossing.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../visualcrossing.js';
+
+describe('visual-crossing provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds service URL', () => {
+    process.env.VISUAL_CROSSING_API_KEY = 'test';
+    const url = buildRequest({ endpoint: 'timeline', location: 'Austin,TX' });
+    expect(url).toBe('https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline?location=Austin%2CTX&key=test');
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.VISUAL_CROSSING_API_KEY = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ endpoint: 'timeline', location: 'Austin,TX' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/visualcrossing.d.ts
+++ b/packages/providers/visualcrossing.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "visual-crossing";
+export declare const baseUrl = "https://weather.visualcrossing.com";
+export interface Params {
+    endpoint: string;
+    location: string;
+}
+export declare function buildRequest({ endpoint, location }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/visualcrossing.js
+++ b/packages/providers/visualcrossing.js
@@ -1,0 +1,13 @@
+export const slug = 'visual-crossing';
+export const baseUrl = 'https://weather.visualcrossing.com';
+export function buildRequest({ endpoint, location }) {
+    const key = process.env.VISUAL_CROSSING_API_KEY;
+    if (!key)
+        throw new Error('VISUAL_CROSSING_API_KEY missing');
+    const loc = encodeURIComponent(location);
+    return `${baseUrl}/VisualCrossingWebServices/rest/services/${endpoint}?location=${loc}&key=${key}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/visualcrossing.ts
+++ b/packages/providers/visualcrossing.ts
@@ -1,0 +1,19 @@
+export const slug = 'visual-crossing';
+export const baseUrl = 'https://weather.visualcrossing.com';
+
+export interface Params {
+  endpoint: string;
+  location: string;
+}
+
+export function buildRequest({ endpoint, location }: Params): string {
+  const key = process.env.VISUAL_CROSSING_API_KEY;
+  if (!key) throw new Error('VISUAL_CROSSING_API_KEY missing');
+  const loc = encodeURIComponent(location);
+  return `${baseUrl}/VisualCrossingWebServices/rest/services/${endpoint}?location=${loc}&key=${key}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "visual-crossing", "category": "weather", "accessRoute": "REST", "baseUrl": "https://weather.visualcrossing.com"}
 ]


### PR DESCRIPTION
## Summary
- add Visual Crossing weather provider
- test Visual Crossing request URL formation
- export Visual Crossing provider and add to manifest

## Testing
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348b9f26883239c5b4f43b95deaec