### PR TITLE
feat: add NASA GIBS provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — NASA GIBS provider module
+  - Summary: Added GIBS provider with WMTS REST/KVP builders, token-aware tile fetcher, and tests.
+  - Files: `packages/providers/gibs.ts`, `packages/providers/index.ts`, `packages/providers/test/gibs.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/gibs.d.ts
+++ b/packages/providers/gibs.d.ts
@@ -1,0 +1,40 @@
+export declare const slug = "nasa-gibs";
+export declare const baseUrl = "https://gibs.earthdata.nasa.gov";
+export type RestParams = {
+    type?: 'rest';
+    epsg: string;
+    layer: string;
+    tms: string;
+    z: string;
+    y: string;
+    x: string;
+    ext: string;
+    time?: string;
+};
+export type KvpParams = {
+    type: 'kvp';
+    epsg: string;
+    layer: string;
+    tileMatrixSet: string;
+    tileMatrix: string;
+    tileRow: string;
+    tileCol: string;
+    format: string;
+    time?: string;
+};
+export type XyzParams = {
+    type: 'xyz';
+    z: string;
+    y: string;
+    x: string;
+};
+export type Params = RestParams | KvpParams | XyzParams;
+export declare function buildRequest(params: Params): string;
+export interface DomainsParams {
+    epsg: string;
+    layer: string;
+    tms: string;
+    range: string;
+}
+export declare function buildDomainsRequest({ epsg, layer, tms, range }: DomainsParams): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/gibs.js
+++ b/packages/providers/gibs.js
@@ -1,0 +1,28 @@
+export const slug = 'nasa-gibs';
+export const baseUrl = 'https://gibs.earthdata.nasa.gov';
+export function buildRequest(params) {
+    if (params.type === 'kvp') {
+        const { epsg, layer, tileMatrixSet, tileMatrix, tileRow, tileCol, format, time } = params;
+        const timePart = time ? `&time=${time}` : '';
+        return `${baseUrl}/wmts/epsg${epsg}/best/wmts.cgi?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=${layer}&STYLE=&TILEMATRIXSET=${tileMatrixSet}&TILEMATRIX=${tileMatrix}&TILEROW=${tileRow}&TILECOL=${tileCol}&FORMAT=${encodeURIComponent(format)}${timePart}`;
+    }
+    if (params.type === 'xyz') {
+        const { z, y, x } = params;
+        const layer = 'MODIS_Terra_CorrectedReflectance_TrueColor';
+        const time = '2020-06-01';
+        const tms = `GoogleMapsCompatible_Level${z}`;
+        return `${baseUrl}/wmts/epsg3857/best/${layer}/default/${time}/${tms}/${z}/${y}/${x}.jpg`;
+    }
+    const { epsg, layer, tms, z, y, x, ext, time } = params;
+    const timePart = time ? `${time}/` : '';
+    return `${baseUrl}/wmts/epsg${epsg}/best/${layer}/default/${timePart}${tms}/${z}/${y}/${x}.${ext}`;
+}
+export function buildDomainsRequest({ epsg, layer, tms, range }) {
+    return `${baseUrl}/wmts/epsg${epsg}/best/1.0.0/${layer}/default/${tms}/all/${range}.xml`;
+}
+export async function fetchTile(url) {
+    const token = process.env.EARTHDATA_TOKEN;
+    const fullUrl = token ? `${url}${url.includes('?') ? '&' : '?'}token=${token}` : url;
+    const res = await fetch(fullUrl);
+    return res.arrayBuffer();
+}

--- a/packages/providers/gibs.ts
+++ b/packages/providers/gibs.ts
@@ -1,0 +1,74 @@
+export const slug = 'nasa-gibs';
+export const baseUrl = 'https://gibs.earthdata.nasa.gov';
+
+export type RestParams = {
+  type?: 'rest';
+  epsg: string;
+  layer: string;
+  tms: string;
+  z: string;
+  y: string;
+  x: string;
+  ext: string;
+  time?: string;
+};
+
+export type KvpParams = {
+  type: 'kvp';
+  epsg: string;
+  layer: string;
+  tileMatrixSet: string;
+  tileMatrix: string;
+  tileRow: string;
+  tileCol: string;
+  format: string;
+  time?: string;
+};
+
+export type XyzParams = {
+  type: 'xyz';
+  z: string;
+  y: string;
+  x: string;
+};
+
+export type Params = RestParams | KvpParams | XyzParams;
+
+export function buildRequest(params: Params): string {
+  if (params.type === 'kvp') {
+    const { epsg, layer, tileMatrixSet, tileMatrix, tileRow, tileCol, format, time } = params;
+    const timePart = time ? `&time=${time}` : '';
+    return `${baseUrl}/wmts/epsg${epsg}/best/wmts.cgi?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=${layer}&STYLE=&TILEMATRIXSET=${tileMatrixSet}&TILEMATRIX=${tileMatrix}&TILEROW=${tileRow}&TILECOL=${tileCol}&FORMAT=${encodeURIComponent(format)}${timePart}`;
+  }
+
+  if (params.type === 'xyz') {
+    const { z, y, x } = params;
+    const layer = 'MODIS_Terra_CorrectedReflectance_TrueColor';
+    const time = '2020-06-01';
+    const tms = `GoogleMapsCompatible_Level${z}`;
+    return `${baseUrl}/wmts/epsg3857/best/${layer}/default/${time}/${tms}/${z}/${y}/${x}.jpg`;
+  }
+
+  const { epsg, layer, tms, z, y, x, ext, time } = params;
+  const timePart = time ? `${time}/` : '';
+  return `${baseUrl}/wmts/epsg${epsg}/best/${layer}/default/${timePart}${tms}/${z}/${y}/${x}.${ext}`;
+}
+
+export interface DomainsParams {
+  epsg: string;
+  layer: string;
+  tms: string;
+  range: string;
+}
+
+export function buildDomainsRequest({ epsg, layer, tms, range }: DomainsParams): string {
+  return `${baseUrl}/wmts/epsg${epsg}/best/1.0.0/${layer}/default/${tms}/all/${range}.xml`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const token = process.env.EARTHDATA_TOKEN;
+  const fullUrl = token ? `${url}${url.includes('?') ? '&' : '?'}token=${token}` : url;
+  const res = await fetch(fullUrl);
+  return res.arrayBuffer();
+}
+

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as gibs from './gibs.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as gibs from './gibs.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as gibs from './gibs.js';

--- a/packages/providers/test/gibs.test.ts
+++ b/packages/providers/test/gibs.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, buildDomainsRequest, fetchTile } from '../gibs.js';
+
+describe('nasa gibs provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.EARTHDATA_TOKEN;
+  });
+
+  it('builds EPSG:4326 WMTS REST URL', () => {
+    const url = buildRequest({
+      epsg: '4326',
+      layer: 'BlueMarble_ShadedRelief',
+      tms: '250m',
+      z: '3',
+      y: '1',
+      x: '2',
+      ext: 'png',
+    });
+    expect(url).toBe('https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/BlueMarble_ShadedRelief/default/250m/3/1/2.png');
+  });
+
+  it('builds XYZ alias URL for EPSG:3857', () => {
+    const url = buildRequest({ type: 'xyz', z: '3', y: '1', x: '2' });
+    expect(url).toBe('https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2020-06-01/GoogleMapsCompatible_Level3/3/1/2.jpg');
+  });
+
+  it('builds DescribeDomains URL', () => {
+    const url = buildDomainsRequest({
+      epsg: '4326',
+      layer: 'BlueMarble_ShadedRelief',
+      tms: '250m',
+      range: '2000-01-01--2020-01-01',
+    });
+    expect(url).toBe('https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/BlueMarble_ShadedRelief/default/250m/all/2000-01-01--2020-01-01.xml');
+  });
+
+  it('appends EARTHDATA token when fetching tile', async () => {
+    process.env.EARTHDATA_TOKEN = 'secret';
+    const mock = vi.fn().mockResolvedValue({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({
+      epsg: '4326',
+      layer: 'BlueMarble_ShadedRelief',
+      tms: '250m',
+      z: '3',
+      y: '1',
+      x: '2',
+      ext: 'png',
+    });
+    await fetchTile(url);
+    expect(mock).toHaveBeenCalledWith(`${url}?token=secret`);
+  });
+});
+

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "nasa-gibs", "category": "imagery", "accessRoute": "WMTS", "baseUrl": "https://gibs.earthdata.nasa.gov"}
 ]


### PR DESCRIPTION
## Summary
- add nasa-gibs provider with WMTS REST, KVP, and XYZ helpers
- support EARTHDATA token in tile fetches
- include gibs in provider manifest, index, and changelog

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348bae43883238685ac17fb332865