### PR TITLE
feat(providers): add NEXRAD Level II provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — NEXRAD Level II provider module
+  - Summary: Added `nexrad-l2` provider that builds object URLs and fetches radar tiles.
+  - Files: `packages/providers/nexrad.ts`, `packages/providers/index.ts`, `packages/providers/test/nexrad.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`; `pnpm lint` fails in `apps/web`, and `pnpm test` fails in `proxy-server` tracestrack test.

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nexrad from './nexrad.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nexrad from './nexrad.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nexrad from './nexrad.js';

--- a/packages/providers/nexrad.d.ts
+++ b/packages/providers/nexrad.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "nexrad-l2";
+export declare const baseUrl = "https://noaa-nexrad-level2.s3.amazonaws.com";
+export interface Params {
+    station: string;
+    datetime: Date;
+}
+export declare function buildRequest({ station, datetime }: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/nexrad.js
+++ b/packages/providers/nexrad.js
@@ -1,0 +1,16 @@
+export const slug = 'nexrad-l2';
+export const baseUrl = 'https://noaa-nexrad-level2.s3.amazonaws.com';
+export function buildRequest({ station, datetime }) {
+    const yyyy = datetime.getUTCFullYear().toString().padStart(4, '0');
+    const mm = String(datetime.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(datetime.getUTCDate()).padStart(2, '0');
+    const hh = String(datetime.getUTCHours()).padStart(2, '0');
+    const min = String(datetime.getUTCMinutes()).padStart(2, '0');
+    const ss = String(datetime.getUTCSeconds()).padStart(2, '0');
+    const key = `${station}${yyyy}${mm}${dd}_${hh}${min}${ss}_V06`;
+    return `${baseUrl}/${yyyy}/${mm}/${dd}/${station}/${key}`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/nexrad.ts
+++ b/packages/providers/nexrad.ts
@@ -1,0 +1,24 @@
+export const slug = 'nexrad-l2';
+export const baseUrl = 'https://noaa-nexrad-level2.s3.amazonaws.com';
+
+export interface Params {
+  station: string;
+  datetime: Date;
+}
+
+export function buildRequest({ station, datetime }: Params): string {
+  const yyyy = datetime.getUTCFullYear().toString().padStart(4, '0');
+  const mm = String(datetime.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(datetime.getUTCDate()).padStart(2, '0');
+  const hh = String(datetime.getUTCHours()).padStart(2, '0');
+  const min = String(datetime.getUTCMinutes()).padStart(2, '0');
+  const ss = String(datetime.getUTCSeconds()).padStart(2, '0');
+  const key = `${station}${yyyy}${mm}${dd}_${hh}${min}${ss}_V06`;
+  return `${baseUrl}/${yyyy}/${mm}/${dd}/${station}/${key}`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}
+

--- a/packages/providers/test/nexrad.test.ts
+++ b/packages/providers/test/nexrad.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchTile } from '../nexrad.js';
+
+describe('nexrad provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds object key', () => {
+    const datetime = new Date(Date.UTC(2025, 7, 29, 0, 26, 12));
+    const url = buildRequest({ station: 'KABR', datetime });
+    expect(url).toMatchInlineSnapshot(
+      '"https://noaa-nexrad-level2.s3.amazonaws.com/2025/08/29/KABR/KABR20250829_002612_V06"'
+    );
+  });
+
+  it('fetches array buffer', async () => {
+    const mock = vi
+      .fn()
+      .mockResolvedValue({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(1)) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ station: 'KABR', datetime: new Date(0) });
+    await fetchTile(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});
+

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "nexrad-l2", "category": "radar", "accessRoute": "S3", "baseUrl": "https://noaa-nexrad-level2.s3.amazonaws.com"}
 ]


### PR DESCRIPTION
## Summary
- add `nexrad-l2` provider to construct NEXRAD Level II object URLs and fetch ArrayBuffer tiles
- export provider in package index and manifest
- document provider addition in implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: apps/web lint errors)*
- `pnpm test` *(fails: proxy-server test)*

------
https://chatgpt.com/codex/tasks/task_e_68b348bb832883238a091e17268ddaf4