### PR TITLE
feat: add NOAA MRMS provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — NOAA MRMS provider module
+  - Summary: Added `noaa-mrms` provider with request builder, binary tile fetch, tests, and manifest entry.
+  - Files: `packages/providers/mrms.ts`, `packages/providers/index.ts`, `packages/providers/test/mrms.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -1,4 +1,5 @@
 export * as nws from './nws.js';
 export * as metno from './metno.js';
+export * as mrms from './mrms.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -1,4 +1,5 @@
 export * as nws from './nws.js';
 export * as metno from './metno.js';
+export * as mrms from './mrms.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,4 +1,5 @@
 export * as nws from './nws.js';
 export * as metno from './metno.js';
+export * as mrms from './mrms.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';

--- a/packages/providers/mrms.d.ts
+++ b/packages/providers/mrms.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "noaa-mrms";
+export declare const baseUrl = "https://noaa-mrms-pds.s3.amazonaws.com";
+export interface Params {
+    product: string;
+    datetime: Date;
+}
+export declare function buildRequest({ product, datetime }: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/mrms.js
+++ b/packages/providers/mrms.js
@@ -1,0 +1,21 @@
+export const slug = 'noaa-mrms';
+export const baseUrl = 'https://noaa-mrms-pds.s3.amazonaws.com';
+function pad(n) {
+    return String(n).padStart(2, '0');
+}
+export function buildRequest({ product, datetime }) {
+    const y = datetime.getUTCFullYear();
+    const m = pad(datetime.getUTCMonth() + 1);
+    const d = pad(datetime.getUTCDate());
+    const hh = pad(datetime.getUTCHours());
+    const mm = pad(datetime.getUTCMinutes());
+    const ymd = `${y}${m}${d}`;
+    const time = `${ymd}-${hh}${mm}`;
+    return `${baseUrl}/${product}/${ymd}/${product}_${time}_GEO.tif`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    if (!res.ok)
+        throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+    return res.arrayBuffer();
+}

--- a/packages/providers/mrms.ts
+++ b/packages/providers/mrms.ts
@@ -1,0 +1,28 @@
+export const slug = 'noaa-mrms';
+export const baseUrl = 'https://noaa-mrms-pds.s3.amazonaws.com';
+
+export interface Params {
+  product: string;
+  datetime: Date;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+export function buildRequest({ product, datetime }: Params): string {
+  const y = datetime.getUTCFullYear();
+  const m = pad(datetime.getUTCMonth() + 1);
+  const d = pad(datetime.getUTCDate());
+  const hh = pad(datetime.getUTCHours());
+  const mm = pad(datetime.getUTCMinutes());
+  const ymd = `${y}${m}${d}`;
+  const time = `${ymd}-${hh}${mm}`;
+  return `${baseUrl}/${product}/${ymd}/${product}_${time}_GEO.tif`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+  return res.arrayBuffer();
+}

--- a/packages/providers/test/mrms.test.ts
+++ b/packages/providers/test/mrms.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchTile } from '../mrms.js';
+
+describe('noaa-mrms provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds tile URL', () => {
+    const dt = new Date(Date.UTC(2024, 0, 2, 3, 4));
+    const url = buildRequest({ product: 'PrecipRate', datetime: dt });
+    expect(url).toBe('https://noaa-mrms-pds.s3.amazonaws.com/PrecipRate/20240102/PrecipRate_20240102-0304_GEO.tif');
+  });
+
+  it('fetches tile binary', async () => {
+    const dt = new Date(Date.UTC(2024, 0, 2, 3, 4));
+    const url = buildRequest({ product: 'PrecipRate', datetime: dt });
+    const mock = vi.fn().mockResolvedValue({ ok: true, arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)) });
+    // @ts-ignore
+    global.fetch = mock;
+    await fetchTile(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "noaa-mrms", "category": "weather", "accessRoute": "REST", "baseUrl": "https://noaa-mrms-pds.s3.amazonaws.com"}
 ]


### PR DESCRIPTION
## Summary
- add `noaa-mrms` provider module with request builder and binary tile fetch
- export provider and register in manifest
- cover MRMS URL builder with tests and log the change

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348bc44688323a5560334c11f0c93