### PR TITLE
feat(providers): add NOAA GOES provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — NOAA GOES provider module
+  - Summary: Added GOES16 provider with DOY path builder and binary fetch.
+  - Files: `packages/providers/goes.ts`, `packages/providers/index.ts`, `packages/providers/test/goes.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/goes.d.ts
+++ b/packages/providers/goes.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "noaa-goes";
+export declare const baseUrl = "https://noaa-goes16.s3.amazonaws.com";
+export interface Params {
+    satellite: string;
+    product: string;
+    datetime: Date;
+}
+export declare function buildRequest({ satellite, product, datetime }: Params): string;
+export declare function fetchBinary(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/goes.js
+++ b/packages/providers/goes.js
@@ -1,0 +1,17 @@
+export const slug = 'noaa-goes';
+export const baseUrl = 'https://noaa-goes16.s3.amazonaws.com';
+export function buildRequest({ satellite, product, datetime }) {
+    const year = datetime.getUTCFullYear();
+    const startOfYear = Date.UTC(year, 0, 0);
+    const doy = Math.floor((datetime.getTime() - startOfYear) / 86400000);
+    const ddd = String(doy).padStart(3, '0');
+    const hh = String(datetime.getUTCHours()).padStart(2, '0');
+    const mm = String(datetime.getUTCMinutes()).padStart(2, '0');
+    const ss = String(datetime.getUTCSeconds()).padStart(2, '0');
+    const filename = `OR_${product}_${satellite}_s${year}${ddd}${hh}${mm}${ss}.nc`;
+    return `${baseUrl}/${product}/${year}/${ddd}/${hh}/${filename}`;
+}
+export async function fetchBinary(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/goes.ts
+++ b/packages/providers/goes.ts
@@ -1,0 +1,25 @@
+export const slug = 'noaa-goes';
+export const baseUrl = 'https://noaa-goes16.s3.amazonaws.com';
+
+export interface Params {
+  satellite: string;
+  product: string;
+  datetime: Date;
+}
+
+export function buildRequest({ satellite, product, datetime }: Params): string {
+  const year = datetime.getUTCFullYear();
+  const startOfYear = Date.UTC(year, 0, 0);
+  const doy = Math.floor((datetime.getTime() - startOfYear) / 86400000);
+  const ddd = String(doy).padStart(3, '0');
+  const hh = String(datetime.getUTCHours()).padStart(2, '0');
+  const mm = String(datetime.getUTCMinutes()).padStart(2, '0');
+  const ss = String(datetime.getUTCSeconds()).padStart(2, '0');
+  const filename = `OR_${product}_${satellite}_s${year}${ddd}${hh}${mm}${ss}.nc`;
+  return `${baseUrl}/${product}/${year}/${ddd}/${hh}/${filename}`;
+}
+
+export async function fetchBinary(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -1,3 +1,4 @@
+export * as goes from './goes.js';
 export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -1,3 +1,4 @@
+export * as goes from './goes.js';
 export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,3 +1,4 @@
+export * as goes from './goes.js';
 export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';

--- a/packages/providers/test/goes.test.ts
+++ b/packages/providers/test/goes.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequest } from '../goes.js';
+
+describe('noaa goes provider', () => {
+  it('builds S3 URL with DOY', () => {
+    const datetime = new Date(Date.UTC(2024, 2, 29, 16, 0, 0));
+    const url = buildRequest({ satellite: 'G16', product: 'ABI-L2-CMIPC', datetime });
+    expect(url).toBe(
+      'https://noaa-goes16.s3.amazonaws.com/ABI-L2-CMIPC/2024/089/16/OR_ABI-L2-CMIPC_G16_s2024089160000.nc'
+    );
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "noaa-goes", "category": "satellite", "accessRoute": "S3", "baseUrl": "https://noaa-goes16.s3.amazonaws.com"}
 ]


### PR DESCRIPTION
## Summary
- add NOAA GOES provider with DOY-based path builder and binary fetch
- expose provider via package index and manifest
- document change in implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348bcbbec8323a0b1e938bb2e2c39