### PR TITLE
feat(providers): add NWS radar tiles provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — NWS radar tiles provider
+  - Summary: Added NWS radar tile provider with canonical XYZ path builder and binary fetch function.
+  - Files: `packages/providers/nws-radar-tiles.ts`, `packages/providers/nws-radar-tiles.js`, `packages/providers/nws-radar-tiles.d.ts`, `packages/providers/index.ts`, `packages/providers/index.js`, `packages/providers/index.d.ts`, `packages/providers/test/nws-radar-tiles.test.ts`, `providers.json`
+  - Verification: `pnpm lint` (fails in apps/web), `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nwsRadarTiles from './nws-radar-tiles.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nwsRadarTiles from './nws-radar-tiles.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nwsRadarTiles from './nws-radar-tiles.js';

--- a/packages/providers/nws-radar-tiles.d.ts
+++ b/packages/providers/nws-radar-tiles.d.ts
@@ -1,0 +1,10 @@
+export declare const slug = "nws-radar-tiles";
+export declare const baseUrl = "https://tiles.weather.gov";
+export interface Params {
+    layer: string;
+    z: number;
+    x: number;
+    y: number;
+}
+export declare function buildRequest({ layer, z, x, y }: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/nws-radar-tiles.js
+++ b/packages/providers/nws-radar-tiles.js
@@ -1,0 +1,9 @@
+export const slug = 'nws-radar-tiles';
+export const baseUrl = 'https://tiles.weather.gov';
+export function buildRequest({ layer, z, x, y }) {
+    return `${baseUrl}/tiles/radar/${layer}/${z}/${x}/${y}.png`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/nws-radar-tiles.ts
+++ b/packages/providers/nws-radar-tiles.ts
@@ -1,0 +1,18 @@
+export const slug = 'nws-radar-tiles';
+export const baseUrl = 'https://tiles.weather.gov';
+
+export interface Params {
+  layer: string;
+  z: number;
+  x: number;
+  y: number;
+}
+
+export function buildRequest({ layer, z, x, y }: Params): string {
+  return `${baseUrl}/tiles/radar/${layer}/${z}/${x}/${y}.png`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}

--- a/packages/providers/test/nws-radar-tiles.test.ts
+++ b/packages/providers/test/nws-radar-tiles.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchTile } from '../nws-radar-tiles.js';
+
+describe('nws radar tiles provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds canonical tile path', () => {
+    const url = buildRequest({ layer: 'conus', z: 3, x: 2, y: 1 });
+    expect(url).toBe('https://tiles.weather.gov/tiles/radar/conus/3/2/1.png');
+  });
+
+  it('fetches tile as arrayBuffer', async () => {
+    const mockBuffer = new ArrayBuffer(8);
+    const mock = vi.fn().mockResolvedValue({ arrayBuffer: () => Promise.resolve(mockBuffer) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ layer: 'conus', z: 3, x: 2, y: 1 });
+    const data = await fetchTile(url);
+    expect(mock).toHaveBeenCalledWith(url);
+    expect(data).toBe(mockBuffer);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "nws-radar-tiles", "category": "radar", "accessRoute": "XYZ", "baseUrl": "https://tiles.weather.gov"}
 ]


### PR DESCRIPTION
## Summary
- add `nws-radar-tiles` provider for NWS radar imagery
- expose canonical tile path builder and binary tile fetcher
- test URL formation, update manifests and implementation log

## Testing
- `pnpm lint` *(fails: Unexpected any in apps/web page.tsx)*
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348bd7d6c8323bdaf86718a0d341e