### PR TITLE
feat: add JMA Himawari-8 provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — JMA Himawari-8 provider
+  - Summary: Added Himawari-8 satellite provider with key builder and binary tile fetch.
+  - Files: `packages/providers/himawari8.*`, `packages/providers/index.*`, `packages/providers/test/himawari8.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`

--- a/packages/providers/himawari8.d.ts
+++ b/packages/providers/himawari8.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "jma-himawari8";
+export declare const baseUrl = "https://himawari8.s3.amazonaws.com";
+export interface Params {
+    product: string;
+    datetime: Date;
+    region: string;
+}
+export declare function buildRequest({ product, datetime, region }: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/himawari8.js
+++ b/packages/providers/himawari8.js
@@ -1,0 +1,16 @@
+export const slug = 'jma-himawari8';
+export const baseUrl = 'https://himawari8.s3.amazonaws.com';
+export function buildRequest({ product, datetime, region }) {
+    const YYYY = datetime.getUTCFullYear().toString();
+    const MM = String(datetime.getUTCMonth() + 1).padStart(2, '0');
+    const DD = String(datetime.getUTCDate()).padStart(2, '0');
+    const HH = String(datetime.getUTCHours()).padStart(2, '0');
+    const mm = String(datetime.getUTCMinutes()).padStart(2, '0');
+    const SS = String(datetime.getUTCSeconds()).padStart(2, '0');
+    const cleanRegion = region.replace(/^\/+/, '');
+    return `${baseUrl}/${product}/${YYYY}/${MM}/${DD}/${HH}${mm}${SS}/${cleanRegion}`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/himawari8.ts
+++ b/packages/providers/himawari8.ts
@@ -1,0 +1,24 @@
+export const slug = 'jma-himawari8';
+export const baseUrl = 'https://himawari8.s3.amazonaws.com';
+
+export interface Params {
+  product: string;
+  datetime: Date;
+  region: string;
+}
+
+export function buildRequest({ product, datetime, region }: Params): string {
+  const YYYY = datetime.getUTCFullYear().toString();
+  const MM = String(datetime.getUTCMonth() + 1).padStart(2, '0');
+  const DD = String(datetime.getUTCDate()).padStart(2, '0');
+  const HH = String(datetime.getUTCHours()).padStart(2, '0');
+  const mm = String(datetime.getUTCMinutes()).padStart(2, '0');
+  const SS = String(datetime.getUTCSeconds()).padStart(2, '0');
+  const cleanRegion = region.replace(/^\/+/, '');
+  return `${baseUrl}/${product}/${YYYY}/${MM}/${DD}/${HH}${mm}${SS}/${cleanRegion}`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as himawari8 from './himawari8.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as himawari8 from './himawari8.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as himawari8 from './himawari8.js';

--- a/packages/providers/test/himawari8.test.ts
+++ b/packages/providers/test/himawari8.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequest } from '../himawari8.js';
+
+describe('himawari8 provider', () => {
+  it('builds key URL', () => {
+    const dt = new Date('2025-01-02T03:04:05Z');
+    const url = buildRequest({
+      product: 'prod',
+      datetime: dt,
+      region: 'R01/0/0.png',
+    });
+    expect(url).toBe('https://himawari8.s3.amazonaws.com/prod/2025/01/02/030405/R01/0/0.png');
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "jma-himawari8", "category": "satellite", "accessRoute": "REST", "baseUrl": "https://himawari8.s3.amazonaws.com"}
 ]


### PR DESCRIPTION
## Summary
- add JMA Himawari-8 provider module for satellite imagery
- export provider and extend manifest
- log implementation and test key assembly

## Testing
- `pnpm lint` *(fails: apps/web lint errors)*
- `pnpm --filter @atmos/providers test`
- `pnpm test` *(fails: proxy-server tests cannot resolve @atmos/shared-utils)*

------
https://chatgpt.com/codex/tasks/task_e_68b348bfb2e8832381fe516ae83e8054