### PR TITLE
feat(providers): add rainviewer module

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — RainViewer provider module
+  - Summary: Added RainViewer tile URL builder and binary fetch helper with tests and manifest update.
+  - Files: `packages/providers/rainviewer.ts`, `packages/providers/index.ts`, `packages/providers/test/rainviewer.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as rainviewer from './rainviewer.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as rainviewer from './rainviewer.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as rainviewer from './rainviewer.js';

--- a/packages/providers/rainviewer.d.ts
+++ b/packages/providers/rainviewer.d.ts
@@ -1,0 +1,13 @@
+export declare const slug = "rainviewer";
+export declare const baseUrl = "https://api.rainviewer.com";
+export interface Params {
+    ts: number;
+    size: number;
+    z: number;
+    x: number;
+    y: number;
+    color: number;
+    options: string;
+}
+export declare function buildRequest({ ts, size, z, x, y, color, options, }: Params): Promise<string>;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/rainviewer.js
+++ b/packages/providers/rainviewer.js
@@ -1,0 +1,16 @@
+export const slug = 'rainviewer';
+export const baseUrl = 'https://api.rainviewer.com';
+export async function buildRequest({ ts, size, z, x, y, color, options, }) {
+    const indexUrl = `${baseUrl}/public/weather-maps.json`;
+    const res = await fetch(indexUrl);
+    const data = await res.json();
+    const frames = [...(data.radar?.past || []), ...(data.radar?.nowcast || [])];
+    const frame = frames.find((f) => f.time === ts);
+    if (!frame)
+        throw new Error('Timestamp not found');
+    return `${data.host}${frame.path}/${size}/${z}/${x}/${y}/${color}/${options}.png`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/rainviewer.ts
+++ b/packages/providers/rainviewer.ts
@@ -1,0 +1,36 @@
+export const slug = 'rainviewer';
+export const baseUrl = 'https://api.rainviewer.com';
+
+export interface Params {
+  ts: number;
+  size: number;
+  z: number;
+  x: number;
+  y: number;
+  color: number;
+  options: string;
+}
+
+export async function buildRequest({
+  ts,
+  size,
+  z,
+  x,
+  y,
+  color,
+  options,
+}: Params): Promise<string> {
+  const indexUrl = `${baseUrl}/public/weather-maps.json`;
+  const res = await fetch(indexUrl);
+  const data = await res.json();
+  const frames = [...(data.radar?.past || []), ...(data.radar?.nowcast || [])];
+  const frame = frames.find((f: any) => f.time === ts);
+  if (!frame) throw new Error('Timestamp not found');
+  return `${data.host}${frame.path}/${size}/${z}/${x}/${y}/${color}/${options}.png`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}
+

--- a/packages/providers/test/rainviewer.test.ts
+++ b/packages/providers/test/rainviewer.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchTile } from '../rainviewer.js';
+
+describe('rainviewer provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds tile URL from index', async () => {
+    const index = {
+      host: 'https://tile.test',
+      radar: { past: [{ time: 1, path: '/v2/radar/1' }], nowcast: [] },
+    };
+    const json = vi.fn().mockResolvedValue(index);
+    const mock = vi.fn().mockResolvedValue({ json });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = await buildRequest({ ts: 1, size: 256, z: 2, x: 3, y: 4, color: 5, options: '0_0' });
+    expect(mock).toHaveBeenCalledWith('https://api.rainviewer.com/public/weather-maps.json');
+    expect(url).toBe('https://tile.test/v2/radar/1/256/2/3/4/5/0_0.png');
+  });
+
+  it('fetches binary tile', async () => {
+    const arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(0));
+    const mock = vi.fn().mockResolvedValue({ arrayBuffer });
+    // @ts-ignore
+    global.fetch = mock;
+    await fetchTile('https://tile.test/tile.png');
+    expect(mock).toHaveBeenCalledWith('https://tile.test/tile.png');
+  });
+});
+

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "rainviewer", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.rainviewer.com"}
 ]


### PR DESCRIPTION
## Summary
- add RainViewer provider for radar tiles and binary fetch helper
- expose RainViewer from providers package and manifest
- test URL resolution against mocked index

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348c0775083239e233ffd13cc4705