### PR TITLE
feat: add NOAA CO-OPS provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — NOAA CO-OPS provider module
+  - Summary: Added NOAA CO-OPS provider with canonical query ordering and tests; updated manifest and exports.
+  - Files: `packages/providers/noaa-coops.*`, `packages/providers/index.*`, `packages/providers/test/noaa-coops.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as noaaCoops from './noaa-coops.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as noaaCoops from './noaa-coops.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as noaaCoops from './noaa-coops.js';

--- a/packages/providers/noaa-coops.d.ts
+++ b/packages/providers/noaa-coops.d.ts
@@ -1,0 +1,13 @@
+export declare const slug = "noaa-coops";
+export declare const baseUrl = "https://api.tidesandcurrents.noaa.gov/api/prod";
+export interface Params {
+    product: string;
+    station: string;
+    begin_date: string;
+    end_date: string;
+    units: string;
+    time_zone: string;
+    format: string;
+}
+export declare function buildRequest({ product, station, begin_date, end_date, units, time_zone, format }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/noaa-coops.js
+++ b/packages/providers/noaa-coops.js
@@ -1,0 +1,17 @@
+export const slug = 'noaa-coops';
+export const baseUrl = 'https://api.tidesandcurrents.noaa.gov/api/prod';
+export function buildRequest({ product, station, begin_date, end_date, units, time_zone, format }) {
+    const params = new URLSearchParams();
+    params.append('product', product);
+    params.append('station', station);
+    params.append('begin_date', begin_date);
+    params.append('end_date', end_date);
+    params.append('units', units);
+    params.append('time_zone', time_zone);
+    params.append('format', format);
+    return `${baseUrl}?${params.toString()}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/noaa-coops.ts
+++ b/packages/providers/noaa-coops.ts
@@ -1,0 +1,29 @@
+export const slug = 'noaa-coops';
+export const baseUrl = 'https://api.tidesandcurrents.noaa.gov/api/prod';
+
+export interface Params {
+  product: string;
+  station: string;
+  begin_date: string;
+  end_date: string;
+  units: string;
+  time_zone: string;
+  format: string;
+}
+
+export function buildRequest({ product, station, begin_date, end_date, units, time_zone, format }: Params): string {
+  const params = new URLSearchParams();
+  params.append('product', product);
+  params.append('station', station);
+  params.append('begin_date', begin_date);
+  params.append('end_date', end_date);
+  params.append('units', units);
+  params.append('time_zone', time_zone);
+  params.append('format', format);
+  return `${baseUrl}?${params.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/test/noaa-coops.test.ts
+++ b/packages/providers/test/noaa-coops.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../noaa-coops.js';
+
+describe('noaa-coops provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds request URL with canonical query order', () => {
+    const url = buildRequest({
+      product: 'water_level',
+      station: '8724580',
+      begin_date: '20200101',
+      end_date: '20200102',
+      units: 'metric',
+      time_zone: 'gmt',
+      format: 'json',
+    });
+    expect(url).toBe('https://api.tidesandcurrents.noaa.gov/api/prod?product=water_level&station=8724580&begin_date=20200101&end_date=20200102&units=metric&time_zone=gmt&format=json');
+  });
+
+  it('calls fetch without headers', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({
+      product: 'water_level',
+      station: '8724580',
+      begin_date: '20200101',
+      end_date: '20200102',
+      units: 'metric',
+      time_zone: 'gmt',
+      format: 'json',
+    });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "noaa-coops", "category": "ocean", "accessRoute": "REST", "baseUrl": "https://api.tidesandcurrents.noaa.gov/api/prod"}
 ]


### PR DESCRIPTION
## Summary
- add NOAA CO-OPS provider module with canonical query ordering
- include golden tests and manifest entries for new provider

## Testing
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348c38afc8323a26cced799dbcd5e