### PR TITLE
feat(providers): add NOAA NDBC provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — NOAA NDBC provider module
+  - Summary: Added provider for NOAA NDBC real-time station data with format-aware fetch.
+  - Files: `packages/providers/noaa-ndbc.ts`, `packages/providers/noaa-ndbc.js`, `packages/providers/noaa-ndbc.d.ts`, `packages/providers/index.ts`, `packages/providers/index.js`, `packages/providers/index.d.ts`, `packages/providers/test/noaa-ndbc.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as noaaNdbc from './noaa-ndbc.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as noaaNdbc from './noaa-ndbc.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as noaaNdbc from './noaa-ndbc.js';

--- a/packages/providers/noaa-ndbc.d.ts
+++ b/packages/providers/noaa-ndbc.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "noaa-ndbc";
+export declare const baseUrl = "https://www.ndbc.noaa.gov";
+export interface Params {
+    station: string;
+    format: 'txt' | 'json';
+}
+export declare function buildRequest({ station, format }: Params): string;
+export declare function fetch(url: string, format: Params['format']): Promise<any>;

--- a/packages/providers/noaa-ndbc.js
+++ b/packages/providers/noaa-ndbc.js
@@ -1,0 +1,9 @@
+export const slug = 'noaa-ndbc';
+export const baseUrl = 'https://www.ndbc.noaa.gov';
+export function buildRequest({ station, format }) {
+    return `${baseUrl}/data/realtime2/${station}.${format}`;
+}
+export async function fetch(url, format) {
+    const res = await globalThis.fetch(url);
+    return format === 'json' ? res.json() : res.text();
+}

--- a/packages/providers/noaa-ndbc.ts
+++ b/packages/providers/noaa-ndbc.ts
@@ -1,0 +1,16 @@
+export const slug = 'noaa-ndbc';
+export const baseUrl = 'https://www.ndbc.noaa.gov';
+
+export interface Params {
+  station: string;
+  format: 'txt' | 'json';
+}
+
+export function buildRequest({ station, format }: Params): string {
+  return `${baseUrl}/data/realtime2/${station}.${format}`;
+}
+
+export async function fetch(url: string, format: Params['format']): Promise<any> {
+  const res = await globalThis.fetch(url);
+  return format === 'json' ? res.json() : res.text();
+}

--- a/packages/providers/test/noaa-ndbc.test.ts
+++ b/packages/providers/test/noaa-ndbc.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequest } from '../noaa-ndbc.js';
+
+describe('noaa-ndbc provider', () => {
+  it('builds station URL', () => {
+    const url = buildRequest({ station: '41009', format: 'txt' });
+    expect(url).toBe('https://www.ndbc.noaa.gov/data/realtime2/41009.txt');
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "noaa-ndbc", "category": "weather", "accessRoute": "REST", "baseUrl": "https://www.ndbc.noaa.gov"}
 ]


### PR DESCRIPTION
## Summary
- add NOAA NDBC provider module with format-aware fetch
- export provider and document in manifest
- test buildRequest URL formation

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348c449e0832390921e796086f720