### PR TITLE
feat(providers): add erddap provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — ERDDAP provider module
+  - Summary: Added ERDDAP provider with env-based base URL and tests for URL composition.
+  - Files: `packages/providers/erddap.ts`, `packages/providers/erddap.js`, `packages/providers/erddap.d.ts`, `packages/providers/index.ts`, `packages/providers/index.js`, `packages/providers/index.d.ts`, `packages/providers/test/erddap.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/erddap.d.ts
+++ b/packages/providers/erddap.d.ts
@@ -1,0 +1,7 @@
+export declare const slug = "erddap";
+export interface Params {
+    dataset: string;
+    query: string;
+}
+export declare function buildRequest({ dataset, query }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/erddap.js
+++ b/packages/providers/erddap.js
@@ -1,0 +1,11 @@
+export const slug = 'erddap';
+export function buildRequest({ dataset, query }) {
+    const base = process.env.ERDDAP_BASE_URL;
+    if (!base)
+        throw new Error('ERDDAP_BASE_URL missing');
+    return `${base}/griddap/${dataset}.json?${query}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/erddap.ts
+++ b/packages/providers/erddap.ts
@@ -1,0 +1,17 @@
+export const slug = 'erddap';
+
+export interface Params {
+  dataset: string;
+  query: string;
+}
+
+export function buildRequest({ dataset, query }: Params): string {
+  const base = process.env.ERDDAP_BASE_URL;
+  if (!base) throw new Error('ERDDAP_BASE_URL missing');
+  return `${base}/griddap/${dataset}.json?${query}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as erddap from './erddap.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as erddap from './erddap.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as erddap from './erddap.js';

--- a/packages/providers/test/erddap.test.ts
+++ b/packages/providers/test/erddap.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../erddap.js';
+
+describe('erddap provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds dataset URL', () => {
+    process.env.ERDDAP_BASE_URL = 'https://example.com';
+    const url = buildRequest({ dataset: 'test-ds', query: 'var=value' });
+    expect(url).toBe('https://example.com/griddap/test-ds.json?var=value');
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.ERDDAP_BASE_URL = 'https://example.com';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ dataset: 'test-ds', query: 'var=value' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "erddap", "category": "ocean", "accessRoute": "REST", "baseUrl": "https://coastwatch.pfeg.noaa.gov/erddap"}
 ]


### PR DESCRIPTION
## Summary
- add ERDDAP provider module with env-based base URL
- export ERDDAP provider in providers index and manifest
- document change in implementation log with tests

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm test` *(fails: proxy-server package entry failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b348c53af48323a3e543dfaa9d103e