### PR TITLE
feat(providers): add NOAA NWM module

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — NOAA NWM provider module
+  - Summary: Added `noaa-nwm` provider with key builder and binary tile fetch, updated manifest and exports.
+  - Files: `packages/providers/nwm.ts`, `packages/providers/index.ts`, `packages/providers/test/nwm.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nwm from './nwm.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nwm from './nwm.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as nwm from './nwm.js';

--- a/packages/providers/nwm.d.ts
+++ b/packages/providers/nwm.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "noaa-nwm";
+export declare const baseUrl = "https://noaa-nwm-pds.s3.amazonaws.com";
+export interface Params {
+    product: string;
+    datetime: Date;
+}
+export declare function buildRequest({ product, datetime }: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer>;

--- a/packages/providers/nwm.js
+++ b/packages/providers/nwm.js
@@ -1,0 +1,17 @@
+export const slug = 'noaa-nwm';
+export const baseUrl = 'https://noaa-nwm-pds.s3.amazonaws.com';
+function formatDate(dt) {
+    const year = dt.getUTCFullYear();
+    const month = String(dt.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(dt.getUTCDate()).padStart(2, '0');
+    const hour = String(dt.getUTCHours()).padStart(2, '0');
+    return `${year}${month}${day}${hour}`;
+}
+export function buildRequest({ product, datetime }) {
+    const stamp = formatDate(datetime);
+    return `${baseUrl}/${product}/${stamp}/`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    return res.arrayBuffer();
+}

--- a/packages/providers/nwm.ts
+++ b/packages/providers/nwm.ts
@@ -1,0 +1,25 @@
+export const slug = 'noaa-nwm';
+export const baseUrl = 'https://noaa-nwm-pds.s3.amazonaws.com';
+
+export interface Params {
+  product: string;
+  datetime: Date;
+}
+
+function formatDate(dt: Date): string {
+  const year = dt.getUTCFullYear();
+  const month = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(dt.getUTCDate()).padStart(2, '0');
+  const hour = String(dt.getUTCHours()).padStart(2, '0');
+  return `${year}${month}${day}${hour}`;
+}
+
+export function buildRequest({ product, datetime }: Params): string {
+  const stamp = formatDate(datetime);
+  return `${baseUrl}/${product}/${stamp}/`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer> {
+  const res = await fetch(url);
+  return res.arrayBuffer();
+}

--- a/packages/providers/test/nwm.test.ts
+++ b/packages/providers/test/nwm.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchTile } from '../nwm.js';
+
+describe('noaa-nwm provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds key path for analysis_assim', () => {
+    const dt = new Date(Date.UTC(2025, 0, 1, 12));
+    const url = buildRequest({ product: 'analysis_assim', datetime: dt });
+    expect(url).toBe('https://noaa-nwm-pds.s3.amazonaws.com/analysis_assim/2025010112/');
+  });
+
+  it('fetches binary tile', async () => {
+    const mock = vi.fn().mockResolvedValue({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ product: 'analysis_assim', datetime: new Date(Date.UTC(2025, 0, 1, 12)) });
+    await fetchTile(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "noaa-nwm", "category": "hydrology", "accessRoute": "S3", "baseUrl": "https://noaa-nwm-pds.s3.amazonaws.com"}
 ]


### PR DESCRIPTION
## Summary
- add `noaa-nwm` provider module with key builder and binary tile fetch
- export provider in index and manifest
- document addition in implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: Unexpected any in apps/web)*
- `pnpm test` *(fails: proxy-server test packageEntryFailure)*

------
https://chatgpt.com/codex/tasks/task_e_68b348c627288323a0699bc9dea1290c