### PR TITLE
feat(providers): add EPA AirNow provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — EPA AirNow provider module
+  - Summary: Added `epa-airnow` provider with request builder, fetch helper, manifest entry, and tests.
+  - Files: `packages/providers/airnow.ts`, `packages/providers/index.ts`, `providers.json`, `packages/providers/test/airnow.test.ts`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/airnow.d.ts
+++ b/packages/providers/airnow.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "epa-airnow";
+export declare const baseUrl = "https://www.airnowapi.org";
+export interface Params {
+    lat: number;
+    lon: number;
+}
+export declare function buildRequest({ lat, lon }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/airnow.js
+++ b/packages/providers/airnow.js
@@ -1,0 +1,18 @@
+export const slug = 'epa-airnow';
+export const baseUrl = 'https://www.airnowapi.org';
+export function buildRequest({ lat, lon }) {
+    const apiKey = process.env.AIRNOW_API_KEY;
+    if (!apiKey)
+        throw new Error('AIRNOW_API_KEY missing');
+    const params = new URLSearchParams({
+        format: 'application/json',
+        latitude: String(lat),
+        longitude: String(lon),
+        API_KEY: apiKey,
+    });
+    return `${baseUrl}/aq/observation/latLong/current?${params.toString()}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/airnow.ts
+++ b/packages/providers/airnow.ts
@@ -1,0 +1,24 @@
+export const slug = 'epa-airnow';
+export const baseUrl = 'https://www.airnowapi.org';
+
+export interface Params {
+  lat: number;
+  lon: number;
+}
+
+export function buildRequest({ lat, lon }: Params): string {
+  const apiKey = process.env.AIRNOW_API_KEY;
+  if (!apiKey) throw new Error('AIRNOW_API_KEY missing');
+  const params = new URLSearchParams({
+    format: 'application/json',
+    latitude: String(lat),
+    longitude: String(lon),
+    API_KEY: apiKey,
+  });
+  return `${baseUrl}/aq/observation/latLong/current?${params.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as airnow from './airnow.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as airnow from './airnow.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as airnow from './airnow.js';

--- a/packages/providers/test/airnow.test.ts
+++ b/packages/providers/test/airnow.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { buildRequest, fetchJson } from '../airnow.js';
+
+describe('airnow provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.AIRNOW_API_KEY;
+  });
+
+  it('builds observation URL with API key', () => {
+    process.env.AIRNOW_API_KEY = 'test';
+    const url = buildRequest({ lat: 10, lon: 20 });
+    expect(url).toBe(
+      'https://www.airnowapi.org/aq/observation/latLong/current?format=application%2Fjson&latitude=10&longitude=20&API_KEY=test'
+    );
+  });
+
+  it('throws if API key missing', () => {
+    expect(() => buildRequest({ lat: 10, lon: 20 })).toThrow('AIRNOW_API_KEY missing');
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.AIRNOW_API_KEY = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lat: 10, lon: 20 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "epa-airnow", "category": "air-quality", "accessRoute": "REST", "baseUrl": "https://www.airnowapi.org"}
 ]


### PR DESCRIPTION
## Summary
- add `epa-airnow` provider module with request builder and fetch helper
- expose new provider via package index and manifest
- document addition in implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348c785748323838a472d24720e2d