### PR TITLE
Add OpenAQ v3 provider module with API key support

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — OpenAQ v3 provider module
+  - Summary: Added OpenAQ v3 provider with optional API key header and unit tests.
+  - Files: `packages/providers/openaq.ts`, `packages/providers/test/openaq.test.ts`, `packages/providers/index.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as openaq from './openaq.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as openaq from './openaq.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as openaq from './openaq.js';

--- a/packages/providers/openaq.d.ts
+++ b/packages/providers/openaq.d.ts
@@ -1,0 +1,9 @@
+export declare const slug = "openaq-v3";
+export declare const baseUrl = "https://api.openaq.org/v3";
+export interface Params {
+    coordinates: string;
+    radius: number;
+    parameter: string;
+}
+export declare function buildRequest({ coordinates, radius, parameter }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/openaq.js
+++ b/packages/providers/openaq.js
@@ -1,0 +1,13 @@
+export const slug = 'openaq-v3';
+export const baseUrl = 'https://api.openaq.org/v3';
+export function buildRequest({ coordinates, radius, parameter }) {
+    return `${baseUrl}/latest?coordinates=${coordinates}&radius=${radius}&parameter=${parameter}`;
+}
+export async function fetchJson(url) {
+    const headers = {};
+    const key = process.env.OPENAQ_API_KEY;
+    if (key)
+        headers['X-API-Key'] = key;
+    const res = await fetch(url, { headers });
+    return res.json();
+}

--- a/packages/providers/openaq.ts
+++ b/packages/providers/openaq.ts
@@ -1,0 +1,20 @@
+export const slug = 'openaq-v3';
+export const baseUrl = 'https://api.openaq.org/v3';
+
+export interface Params {
+  coordinates: string;
+  radius: number;
+  parameter: string;
+}
+
+export function buildRequest({ coordinates, radius, parameter }: Params): string {
+  return `${baseUrl}/latest?coordinates=${coordinates}&radius=${radius}&parameter=${parameter}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const headers: Record<string, string> = {};
+  const key = process.env.OPENAQ_API_KEY;
+  if (key) headers['X-API-Key'] = key;
+  const res = await fetch(url, { headers });
+  return res.json();
+}

--- a/packages/providers/test/openaq.test.ts
+++ b/packages/providers/test/openaq.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../openaq.js';
+
+describe('openaq provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.OPENAQ_API_KEY;
+  });
+
+  it('builds latest URL', () => {
+    const url = buildRequest({ coordinates: '10,20', radius: 1000, parameter: 'pm25' });
+    expect(url).toBe('https://api.openaq.org/v3/latest?coordinates=10,20&radius=1000&parameter=pm25');
+  });
+
+  it('injects API key header when present', async () => {
+    process.env.OPENAQ_API_KEY = 'key';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ coordinates: '10,20', radius: 1000, parameter: 'pm25' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url, { headers: { 'X-API-Key': 'key' } });
+  });
+
+  it('omits API key header when absent', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ coordinates: '10,20', radius: 1000, parameter: 'pm25' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url, { headers: {} });
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "openaq-v3", "category": "air quality", "accessRoute": "REST", "baseUrl": "https://api.openaq.org/v3"}
 ]


### PR DESCRIPTION
## Summary
- add OpenAQ v3 provider with request builder and optional `X-API-Key` header
- export provider and list in manifest
- document change in implementation log and add unit tests

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348c81d508323a9cbda6307d039c2