### PR TITLE
feat(providers): add WAQI module

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — WAQI provider module and tile builder
+  - Summary: Added WAQI feed and tile URL builders with tests and manifest/index updates.
+  - Files: `packages/providers/waqi.ts`, `packages/providers/index.ts`, `packages/providers/test/waqi.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.

--- a/docs/open-weather-services.md
+++ b/docs/open-weather-services.md
@@ -17,6 +17,7 @@ This document catalogs freely accessible, non-proprietary weather and space-data
 | **METAR/ASOS** | Surface observations | Text/CSV via `https://aviationweather.gov`; parse to PMTiles | `/api/obs/metar/latest.json` |
 | **AirNow** | U.S. air quality index | Requires free API key; JSON | `/api/air/airnow/...?lat=..&lon=..` |
 | **OpenAQ** | Global air quality | Public REST, no key | `/api/air/openaq/...` |
+| **WAQI** | Global air quality index | Requires token; JSON & tiles | `/api/air/waqi/...` |
 | **NOAA SWPC** | Space weather (solar wind, Kp, auroral oval) | JSON/CSV; no key | `/api/space/kp/latest.json` |
 
 *All services should be routed through `/api/...` endpoints with caching (`shortLived60` unless otherwise required) and attribution metadata.*

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as waqi from './waqi.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as waqi from './waqi.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as waqi from './waqi.js';

--- a/packages/providers/test/waqi.test.ts
+++ b/packages/providers/test/waqi.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, buildTileUrl, fetchJson } from '../waqi.js';
+
+describe('waqi provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds feed URL', () => {
+    process.env.WAQI_TOKEN = 'test';
+    const url = buildRequest({ lat: 10, lon: 20 });
+    expect(url).toBe('https://api.waqi.info/feed/geo:10;20/?token=test');
+  });
+
+  it('builds tile URL', () => {
+    process.env.WAQI_TOKEN = 'test';
+    const url = buildTileUrl({ host: 'https://tiles.waqi.info', z: 1, x: 2, y: 3 });
+    expect(url).toBe('https://tiles.waqi.info/tile/1/2/3.png?token=test');
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.WAQI_TOKEN = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lat: 10, lon: 20 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/waqi.d.ts
+++ b/packages/providers/waqi.d.ts
@@ -1,0 +1,15 @@
+export declare const slug = "waqi";
+export declare const baseUrl = "https://api.waqi.info";
+export interface Params {
+    lat: number;
+    lon: number;
+}
+export declare function buildRequest({ lat, lon }: Params): string;
+export interface TileParams {
+    host: string;
+    z: number;
+    x: number;
+    y: number;
+}
+export declare function buildTileUrl({ host, z, x, y }: TileParams): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/waqi.js
+++ b/packages/providers/waqi.js
@@ -1,0 +1,18 @@
+export const slug = 'waqi';
+export const baseUrl = 'https://api.waqi.info';
+export function buildRequest({ lat, lon }) {
+    const token = process.env.WAQI_TOKEN;
+    if (!token)
+        throw new Error('WAQI_TOKEN missing');
+    return `${baseUrl}/feed/geo:${lat};${lon}/?token=${token}`;
+}
+export function buildTileUrl({ host, z, x, y }) {
+    const token = process.env.WAQI_TOKEN;
+    if (!token)
+        throw new Error('WAQI_TOKEN missing');
+    return `${host}/tile/${z}/${x}/${y}.png?token=${token}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/waqi.ts
+++ b/packages/providers/waqi.ts
@@ -1,0 +1,31 @@
+export const slug = 'waqi';
+export const baseUrl = 'https://api.waqi.info';
+
+export interface Params {
+  lat: number;
+  lon: number;
+}
+
+export function buildRequest({ lat, lon }: Params): string {
+  const token = process.env.WAQI_TOKEN;
+  if (!token) throw new Error('WAQI_TOKEN missing');
+  return `${baseUrl}/feed/geo:${lat};${lon}/?token=${token}`;
+}
+
+export interface TileParams {
+  host: string;
+  z: number;
+  x: number;
+  y: number;
+}
+
+export function buildTileUrl({ host, z, x, y }: TileParams): string {
+  const token = process.env.WAQI_TOKEN;
+  if (!token) throw new Error('WAQI_TOKEN missing');
+  return `${host}/tile/${z}/${x}/${y}.png?token=${token}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "waqi", "category": "air-quality", "accessRoute": "REST", "baseUrl": "https://api.waqi.info"}
 ]


### PR DESCRIPTION
## Summary
- add WAQI provider with feed and tile URL builders
- export WAQI in providers index and manifest
- document provider and record implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: Unexpected any in apps/web)*
- `pnpm test` *(fails: proxy-server@1.0.0 test: `vitest run`)*

------
https://chatgpt.com/codex/tasks/task_e_68b348c8b98483239017428b4f6d824c