### PR TITLE
feat(providers): add OpenWeatherMap air pollution provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,7 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+- [x] 2025-08-30 — OpenWeatherMap air pollution provider
+  - Summary: Added `openweather-air` module with URL builder for `/data/2.5/air_pollution` and tests for API key usage.
+  - Files: `packages/providers/openweather-air.ts`, `packages/providers/index.ts`, `packages/providers/test/openweather-air.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`; `pnpm lint` fails in `apps/web`; `pnpm test` fails in `proxy-server` tests.

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as openweatherAir from './openweather-air.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as openweatherAir from './openweather-air.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as openweatherAir from './openweather-air.js';

--- a/packages/providers/openweather-air.d.ts
+++ b/packages/providers/openweather-air.d.ts
@@ -1,0 +1,8 @@
+export declare const slug = "openweather-air";
+export declare const baseUrl = "https://api.openweathermap.org";
+export interface Params {
+    lat: number;
+    lon: number;
+}
+export declare function buildRequest({ lat, lon }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/openweather-air.js
+++ b/packages/providers/openweather-air.js
@@ -1,0 +1,17 @@
+export const slug = 'openweather-air';
+export const baseUrl = 'https://api.openweathermap.org';
+export function buildRequest({ lat, lon }) {
+    const appid = process.env.OPENWEATHER_API_KEY;
+    if (!appid)
+        throw new Error('OPENWEATHER_API_KEY missing');
+    const params = new URLSearchParams({
+        lat: String(lat),
+        lon: String(lon),
+        appid,
+    });
+    return `${baseUrl}/data/2.5/air_pollution?${params.toString()}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/openweather-air.ts
+++ b/packages/providers/openweather-air.ts
@@ -1,0 +1,23 @@
+export const slug = 'openweather-air';
+export const baseUrl = 'https://api.openweathermap.org';
+
+export interface Params {
+  lat: number;
+  lon: number;
+}
+
+export function buildRequest({ lat, lon }: Params): string {
+  const appid = process.env.OPENWEATHER_API_KEY;
+  if (!appid) throw new Error('OPENWEATHER_API_KEY missing');
+  const params = new URLSearchParams({
+    lat: String(lat),
+    lon: String(lon),
+    appid,
+  });
+  return `${baseUrl}/data/2.5/air_pollution?${params.toString()}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/test/openweather-air.test.ts
+++ b/packages/providers/test/openweather-air.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../openweather-air.js';
+
+describe('openweather-air provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds air pollution URL', () => {
+    process.env.OPENWEATHER_API_KEY = 'test';
+    const url = buildRequest({ lat: 10, lon: 20 });
+    expect(url).toBe('https://api.openweathermap.org/data/2.5/air_pollution?lat=10&lon=20&appid=test');
+  });
+
+  it('calls fetch without headers', async () => {
+    process.env.OPENWEATHER_API_KEY = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ lat: 10, lon: 20 });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "openweather-air", "category": "air-quality", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
 ]


### PR DESCRIPTION
## Summary
- add `openweather-air` provider using OpenWeatherMap air pollution endpoint
- export provider in package index and manifest
- cover URL and API key usage with tests and update implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: apps/web lint errors)*
- `pnpm test` *(fails: proxy-server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b348c8f42083239e7bca30d4dbbd62