### PR TITLE
feat(providers): add Google Air Quality provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — Google Air Quality provider module
+  - Summary: Added Google Air Quality provider with POST request builder and tests.
+  - Files: `packages/providers/google-air.ts`, `packages/providers/index.ts`, `packages/providers/test/google-air.test.ts`, `providers.json`
+  - Verification: `pnpm lint`, `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.

--- a/packages/providers/google-air.d.ts
+++ b/packages/providers/google-air.d.ts
@@ -1,0 +1,17 @@
+export declare const slug = "google-air-quality";
+export declare const baseUrl = "https://airquality.googleapis.com/v1";
+export interface Params {
+    lat: number;
+    lon: number;
+}
+export interface Request {
+    url: string;
+    body: {
+        location: {
+            latitude: number;
+            longitude: number;
+        };
+    };
+}
+export declare function buildRequest({ lat, lon }: Params): Request;
+export declare function fetchJson({ url, body }: Request): Promise<any>;

--- a/packages/providers/google-air.js
+++ b/packages/providers/google-air.js
@@ -1,0 +1,21 @@
+export const slug = 'google-air-quality';
+export const baseUrl = 'https://airquality.googleapis.com/v1';
+export function buildRequest({ lat, lon }) {
+    return {
+        url: `${baseUrl}/currentConditions:lookup?key=${process.env.GOOGLE_CLOUD_KEY}`,
+        body: {
+            location: {
+                latitude: lat,
+                longitude: lon,
+            },
+        },
+    };
+}
+export async function fetchJson({ url, body }) {
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    return res.json();
+}

--- a/packages/providers/google-air.ts
+++ b/packages/providers/google-air.ts
@@ -1,0 +1,38 @@
+export const slug = 'google-air-quality';
+export const baseUrl = 'https://airquality.googleapis.com/v1';
+
+export interface Params {
+  lat: number;
+  lon: number;
+}
+
+export interface Request {
+  url: string;
+  body: {
+    location: {
+      latitude: number;
+      longitude: number;
+    };
+  };
+}
+
+export function buildRequest({ lat, lon }: Params): Request {
+  return {
+    url: `${baseUrl}/currentConditions:lookup?key=${process.env.GOOGLE_CLOUD_KEY}`,
+    body: {
+      location: {
+        latitude: lat,
+        longitude: lon,
+      },
+    },
+  };
+}
+
+export async function fetchJson({ url, body }: Request): Promise<any> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as googleAir from './google-air.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as googleAir from './google-air.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as googleAir from './google-air.js';

--- a/packages/providers/test/google-air.test.ts
+++ b/packages/providers/test/google-air.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../google-air.js';
+
+describe('google air quality provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds request with key and body', () => {
+    process.env.GOOGLE_CLOUD_KEY = 'test';
+    const req = buildRequest({ lat: 1, lon: 2 });
+    expect(req).toEqual({
+      url: 'https://airquality.googleapis.com/v1/currentConditions:lookup?key=test',
+      body: { location: { latitude: 1, longitude: 2 } },
+    });
+  });
+
+  it('posts json body', async () => {
+    process.env.GOOGLE_CLOUD_KEY = 'test';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const req = buildRequest({ lat: 1, lon: 2 });
+    await fetchJson(req);
+    expect(mock).toHaveBeenCalledWith(req.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "google-air-quality", "category": "air-quality", "accessRoute": "REST", "baseUrl": "https://airquality.googleapis.com/v1"}
 ]


### PR DESCRIPTION
## Summary
- add Google Air Quality provider module with POST request builder
- test provider request body and key parameter
- register provider in manifest and implementation log

## Testing
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: Unexpected any in apps/web)*
- `pnpm test` *(fails: proxy-server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b348c9c328832395e22056aaf6b482