### PR TITLE
feat(providers): add NWS alerts provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] ~~2025-08-30 — NWS alerts provider~~
+  - Summary: Added `nws-alerts` provider with filterable query builder and required request headers.
+  - Files: `packages/providers/nws-alerts.ts`, `packages/providers/index.ts`, `packages/providers/test/nws-alerts.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -1,4 +1,5 @@
 export * as nws from './nws.js';
+export * as nwsAlerts from './nws-alerts.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -1,4 +1,5 @@
 export * as nws from './nws.js';
+export * as nwsAlerts from './nws-alerts.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,4 +1,5 @@
 export * as nws from './nws.js';
+export * as nwsAlerts from './nws-alerts.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';

--- a/packages/providers/nws-alerts.d.ts
+++ b/packages/providers/nws-alerts.d.ts
@@ -1,0 +1,11 @@
+export declare const slug = "nws-alerts";
+export declare const baseUrl = "https://api.weather.gov/alerts";
+export interface Params {
+    status?: string;
+    area?: string;
+    point?: string;
+    urgency?: string;
+    event?: string;
+}
+export declare function buildRequest(params?: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/nws-alerts.js
+++ b/packages/providers/nws-alerts.js
@@ -1,0 +1,27 @@
+export const slug = 'nws-alerts';
+export const baseUrl = 'https://api.weather.gov/alerts';
+export function buildRequest(params = {}) {
+    const search = new URLSearchParams();
+    if (params.status)
+        search.set('status', params.status);
+    if (params.area)
+        search.set('area', params.area);
+    if (params.point)
+        search.set('point', params.point);
+    if (params.urgency)
+        search.set('urgency', params.urgency);
+    if (params.event)
+        search.set('event', params.event);
+    const qs = search.toString();
+    return qs ? `${baseUrl}?${qs}` : baseUrl;
+}
+export async function fetchJson(url) {
+    const ua = process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+    const res = await fetch(url, {
+        headers: {
+            'User-Agent': ua,
+            Accept: 'application/geo+json',
+        },
+    });
+    return res.json();
+}

--- a/packages/providers/nws-alerts.ts
+++ b/packages/providers/nws-alerts.ts
@@ -1,0 +1,32 @@
+export const slug = 'nws-alerts';
+export const baseUrl = 'https://api.weather.gov/alerts';
+
+export interface Params {
+  status?: string;
+  area?: string;
+  point?: string;
+  urgency?: string;
+  event?: string;
+}
+
+export function buildRequest(params: Params = {}): string {
+  const search = new URLSearchParams();
+  if (params.status) search.set('status', params.status);
+  if (params.area) search.set('area', params.area);
+  if (params.point) search.set('point', params.point);
+  if (params.urgency) search.set('urgency', params.urgency);
+  if (params.event) search.set('event', params.event);
+  const qs = search.toString();
+  return qs ? `${baseUrl}?${qs}` : baseUrl;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const ua = process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)';
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': ua,
+      Accept: 'application/geo+json',
+    },
+  });
+  return res.json();
+}

--- a/packages/providers/test/nws-alerts.test.ts
+++ b/packages/providers/test/nws-alerts.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../nws-alerts.js';
+
+describe('nws alerts provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds alerts URL with filters', () => {
+    const url = buildRequest({ status: 'actual', area: 'AZ', urgency: 'Immediate' });
+    expect(url).toBe('https://api.weather.gov/alerts?status=actual&area=AZ&urgency=Immediate');
+  });
+
+  it('injects headers', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ area: 'AZ' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url, {
+      headers: {
+        'User-Agent': process.env.NWS_USER_AGENT || '(AtmosInsight, contact@atmosinsight.com)',
+        Accept: 'application/geo+json',
+      },
+    });
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -1,5 +1,6 @@
 [
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
+  {"slug": "nws-alerts", "category": "alerts", "accessRoute": "REST", "baseUrl": "https://api.weather.gov/alerts"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
   {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}


### PR DESCRIPTION
## Summary
- add `nws-alerts` provider with query builder for status/area/point/urgency/event filters
- inject `User-Agent` and `Accept: application/geo+json` headers when fetching
- document provider in manifest and implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348cabc0483239c031445697933b4