### PR TITLE
feat: add NASA FIRMS provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — NASA FIRMS provider module
+  - Summary: Added provider with CSV and WMS/WFS request builders plus tile/text fetch helpers.
+  - Files: `packages/providers/firms.ts`, `packages/providers/index.ts`, `packages/providers/test/firms.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/firms.d.ts
+++ b/packages/providers/firms.d.ts
@@ -1,0 +1,12 @@
+export declare const slug = "nasa-firms";
+export declare const baseUrl = "https://firms.modaps.eosdis.nasa.gov";
+export type Params = {
+    mode: 'csv';
+    path: string;
+} | {
+    mode: 'wms' | 'wfs';
+    dataset: string;
+    params: Record<string, string>;
+};
+export declare function buildRequest(p: Params): string;
+export declare function fetchTile(url: string): Promise<ArrayBuffer | string>;

--- a/packages/providers/firms.js
+++ b/packages/providers/firms.js
@@ -1,0 +1,20 @@
+export const slug = 'nasa-firms';
+export const baseUrl = 'https://firms.modaps.eosdis.nasa.gov';
+export function buildRequest(p) {
+    if (p.mode === 'csv') {
+        return `${baseUrl}/api/area/csv/${p.path}`;
+    }
+    const mapKey = process.env.FIRMS_MAP_KEY;
+    if (!mapKey)
+        throw new Error('FIRMS_MAP_KEY missing');
+    const search = new URLSearchParams(p.params);
+    search.set('MAP_KEY', mapKey);
+    return `${baseUrl}/${p.mode}/${p.dataset}?${search.toString()}`;
+}
+export async function fetchTile(url) {
+    const res = await fetch(url);
+    if (url.includes('/api/area/csv/')) {
+        return res.text();
+    }
+    return res.arrayBuffer();
+}

--- a/packages/providers/firms.ts
+++ b/packages/providers/firms.ts
@@ -1,0 +1,25 @@
+export const slug = 'nasa-firms';
+export const baseUrl = 'https://firms.modaps.eosdis.nasa.gov';
+
+export type Params =
+  | { mode: 'csv'; path: string }
+  | { mode: 'wms' | 'wfs'; dataset: string; params: Record<string, string> };
+
+export function buildRequest(p: Params): string {
+  if (p.mode === 'csv') {
+    return `${baseUrl}/api/area/csv/${p.path}`;
+  }
+  const mapKey = process.env.FIRMS_MAP_KEY;
+  if (!mapKey) throw new Error('FIRMS_MAP_KEY missing');
+  const search = new URLSearchParams(p.params);
+  search.set('MAP_KEY', mapKey);
+  return `${baseUrl}/${p.mode}/${p.dataset}?${search.toString()}`;
+}
+
+export async function fetchTile(url: string): Promise<ArrayBuffer | string> {
+  const res = await fetch(url);
+  if (url.includes('/api/area/csv/')) {
+    return res.text();
+  }
+  return res.arrayBuffer();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as firms from './firms.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as firms from './firms.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as firms from './firms.js';

--- a/packages/providers/test/firms.test.ts
+++ b/packages/providers/test/firms.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { buildRequest, fetchTile } from '../firms.js';
+
+const BASE = 'https://firms.modaps.eosdis.nasa.gov';
+
+describe('firms provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds CSV URL', () => {
+    const url = buildRequest({ mode: 'csv', path: 'VIIRS_SNPP_NRT/world/24h' });
+    expect(url).toBe(`${BASE}/api/area/csv/VIIRS_SNPP_NRT/world/24h`);
+  });
+
+  it('builds WMS URL with MAP_KEY', () => {
+    process.env.FIRMS_MAP_KEY = 'test';
+    const params = { SERVICE: 'WMS', REQUEST: 'GetMap' };
+    const url = buildRequest({ mode: 'wms', dataset: 'VIIRS_SNPP_NRT', params });
+    const search = new URLSearchParams(params);
+    search.set('MAP_KEY', 'test');
+    expect(url).toBe(`${BASE}/wms/VIIRS_SNPP_NRT?${search.toString()}`);
+  });
+
+  it('fetchTile returns text for CSV', async () => {
+    const mock = vi.fn().mockResolvedValue({ text: () => Promise.resolve('ok') });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = `${BASE}/api/area/csv/foo`;
+    const res = await fetchTile(url);
+    expect(res).toBe('ok');
+  });
+
+  it('fetchTile returns arrayBuffer for WMS', async () => {
+    const buf = new ArrayBuffer(8);
+    const mock = vi.fn().mockResolvedValue({ arrayBuffer: () => Promise.resolve(buf) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = `${BASE}/wms/VIIRS_SNPP_NRT?SERVICE=WMS`;
+    const res = await fetchTile(url);
+    expect(res).toBe(buf);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "nasa-firms", "category": "fire", "accessRoute": "WMS/WFS", "baseUrl": "https://firms.modaps.eosdis.nasa.gov"}
 ]


### PR DESCRIPTION
## Summary
- add nasa-firms provider with CSV/WMS/WFS request builders
- export provider and record in manifest and implementation log
- cover CSV and WMS fetch behaviors in tests

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348cb3acc83238862b0b8e2e93fb9