### PR TITLE
feat(providers): add Planetary Computer provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [ ] 2025-08-30 — Planetary Computer STAC provider
+  - Summary: Added `microsoft-pc` module with JSON POST search and manifest entry.
+  - Files: `packages/providers/planetary-computer.*`, `packages/providers/index.*`, `packages/providers/test/planetary-computer.test.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as planetaryComputer from './planetary-computer.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as planetaryComputer from './planetary-computer.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as planetaryComputer from './planetary-computer.js';

--- a/packages/providers/planetary-computer.d.ts
+++ b/packages/providers/planetary-computer.d.ts
@@ -1,0 +1,17 @@
+export declare const slug = "microsoft-pc";
+export declare const baseUrl = "https://planetarycomputer.microsoft.com/api/stac/v1";
+export interface Params {
+    bbox: number[];
+    datetime: string;
+    collections: string[];
+}
+export interface Request {
+    url: string;
+    body: {
+        bbox: number[];
+        datetime: string;
+        collections: string[];
+    };
+}
+export declare function buildRequest({ bbox, datetime, collections }: Params): Request;
+export declare function fetchJson({ url, body }: Request): Promise<any>;

--- a/packages/providers/planetary-computer.js
+++ b/packages/providers/planetary-computer.js
@@ -1,0 +1,18 @@
+export const slug = 'microsoft-pc';
+export const baseUrl = 'https://planetarycomputer.microsoft.com/api/stac/v1';
+export function buildRequest({ bbox, datetime, collections }) {
+    return {
+        url: `${baseUrl}/search`,
+        body: { bbox, datetime, collections },
+    };
+}
+export async function fetchJson({ url, body }) {
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+    });
+    return res.json();
+}

--- a/packages/providers/planetary-computer.ts
+++ b/packages/providers/planetary-computer.ts
@@ -1,0 +1,35 @@
+export const slug = 'microsoft-pc';
+export const baseUrl = 'https://planetarycomputer.microsoft.com/api/stac/v1';
+
+export interface Params {
+  bbox: number[];
+  datetime: string;
+  collections: string[];
+}
+
+export interface Request {
+  url: string;
+  body: {
+    bbox: number[];
+    datetime: string;
+    collections: string[];
+  };
+}
+
+export function buildRequest({ bbox, datetime, collections }: Params): Request {
+  return {
+    url: `${baseUrl}/search`,
+    body: { bbox, datetime, collections },
+  };
+}
+
+export async function fetchJson({ url, body }: Request): Promise<any> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}

--- a/packages/providers/test/planetary-computer.test.ts
+++ b/packages/providers/test/planetary-computer.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../planetary-computer.js';
+
+describe('planetary computer provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds search request', () => {
+    const req = buildRequest({
+      bbox: [1, 2, 3, 4],
+      datetime: '2020-01-01',
+      collections: ['c'],
+    });
+    expect(req.url).toBe(
+      'https://planetarycomputer.microsoft.com/api/stac/v1/search'
+    );
+    expect(req.body).toEqual({
+      bbox: [1, 2, 3, 4],
+      datetime: '2020-01-01',
+      collections: ['c'],
+    });
+  });
+
+  it('posts JSON body', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const req = buildRequest({
+      bbox: [1, 2, 3, 4],
+      datetime: '2020-01-01',
+      collections: ['c'],
+    });
+    await fetchJson(req);
+    expect(mock).toHaveBeenCalledWith(req.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -1,6 +1,32 @@
 [
-  {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
-  {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
-  {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {
+    "slug": "nws-weather",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.weather.gov"
+  },
+  {
+    "slug": "met-norway",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.met.no/weatherapi"
+  },
+  {
+    "slug": "open-meteo",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.open-meteo.com"
+  },
+  {
+    "slug": "openweather-onecall",
+    "category": "weather",
+    "accessRoute": "REST",
+    "baseUrl": "https://api.openweathermap.org"
+  },
+  {
+    "slug": "microsoft-pc",
+    "category": "imagery",
+    "accessRoute": "REST",
+    "baseUrl": "https://planetarycomputer.microsoft.com/api/stac/v1"
+  }
 ]


### PR DESCRIPTION
## Summary
- add `microsoft-pc` STAC provider for Microsoft's Planetary Computer
- support POST JSON search request and index export
- document provider in manifest and implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: Unexpected any in apps/web/src/app/page.tsx)*
- `pnpm test` *(fails: proxy-server vitest resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b348cd0e2083239c540c9620ab8b2f