### PR TITLE
feat: add earth-search provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,8 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+
+- [x] 2025-08-30 — Earth Search provider
+  - Summary: Added `earth-search` provider with POST `/search` builder, JSON fetch, tests, and manifest update.
+  - Files: `packages/providers/earth-search.ts`, `packages/providers/test/earth-search.test.ts`, `packages/providers/index.ts`, `providers.json`
+  - Verification: `pnpm --filter @atmos/providers build`, `pnpm --filter @atmos/providers test`

--- a/packages/providers/earth-search.d.ts
+++ b/packages/providers/earth-search.d.ts
@@ -1,0 +1,16 @@
+export declare const slug = "earth-search";
+export declare const baseUrl = "https://earth-search.aws.element84.com/v1";
+export interface Params {
+    bbox: number[];
+    datetime: string;
+    collections: string[];
+}
+export declare function buildRequest({ bbox, datetime, collections }: Params): {
+    readonly url: "https://earth-search.aws.element84.com/v1/search";
+    readonly body: {
+        readonly bbox: number[];
+        readonly datetime: string;
+        readonly collections: string[];
+    };
+};
+export declare function fetchJson({ url, body }: ReturnType<typeof buildRequest>): Promise<any>;

--- a/packages/providers/earth-search.js
+++ b/packages/providers/earth-search.js
@@ -1,0 +1,16 @@
+export const slug = 'earth-search';
+export const baseUrl = 'https://earth-search.aws.element84.com/v1';
+export function buildRequest({ bbox, datetime, collections }) {
+    return {
+        url: `${baseUrl}/search`,
+        body: { bbox, datetime, collections },
+    };
+}
+export async function fetchJson({ url, body }) {
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    return res.json();
+}

--- a/packages/providers/earth-search.ts
+++ b/packages/providers/earth-search.ts
@@ -1,0 +1,24 @@
+export const slug = 'earth-search';
+export const baseUrl = 'https://earth-search.aws.element84.com/v1';
+
+export interface Params {
+  bbox: number[];
+  datetime: string;
+  collections: string[];
+}
+
+export function buildRequest({ bbox, datetime, collections }: Params) {
+  return {
+    url: `${baseUrl}/search`,
+    body: { bbox, datetime, collections },
+  } as const;
+}
+
+export async function fetchJson({ url, body }: ReturnType<typeof buildRequest>): Promise<any> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as earthsearch from './earth-search.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as earthsearch from './earth-search.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as earthsearch from './earth-search.js';

--- a/packages/providers/test/earth-search.test.ts
+++ b/packages/providers/test/earth-search.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../earth-search.js';
+
+describe('earth-search provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds search request', () => {
+    const req = buildRequest({
+      bbox: [1, 2, 3, 4],
+      datetime: '2020-01-01/2020-02-01',
+      collections: ['sentinel-2'],
+    });
+    expect(req).toEqual({
+      url: 'https://earth-search.aws.element84.com/v1/search',
+      body: {
+        bbox: [1, 2, 3, 4],
+        datetime: '2020-01-01/2020-02-01',
+        collections: ['sentinel-2'],
+      },
+    });
+  });
+
+  it('posts JSON body', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const req = buildRequest({
+      bbox: [1, 2, 3, 4],
+      datetime: '2020-01-01/2020-02-01',
+      collections: ['sentinel-2'],
+    });
+    await fetchJson(req);
+    expect(mock).toHaveBeenCalledWith(req.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "earth-search", "category": "satellite", "accessRoute": "REST", "baseUrl": "https://earth-search.aws.element84.com/v1"}
 ]


### PR DESCRIPTION
## Summary
- add `earth-search` provider with POST `/search` builder and JSON fetch helper
- verify request body with new unit tests
- record provider in manifest and implementation log

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348cdb78083239ff3a591897f20c5