### PR TITLE
feat: add NASA CMR STAC provider

### DIFF
--- a/docs/Implementation_Checklist_and_Status.md
+++ b/docs/Implementation_Checklist_and_Status.md
@@ -156,3 +156,7 @@ This running log tracks production‑ready changes made from 2025‑08‑28 onwa
   - Summary: Added `@atmos/providers` package with NWS Weather, MET Norway, Open-Meteo, and OpenWeather One Call modules plus provider manifest.
   - Files: `packages/providers/*`, `providers.json`
   - Verification: `pnpm --filter @atmos/providers test`; `pnpm test` fails in `proxy-server` tracestrack test.
+- [x] 2025-08-30 — NASA CMR STAC provider module
+  - Summary: Added provider for NASA CMR STAC API with optional Earthdata token support and POST search requests.
+  - Files: `packages/providers/*`, `providers.json`
+  - Verification: `pnpm lint` fails (apps/web), `pnpm --filter @atmos/providers test`

--- a/packages/providers/cmr-stac.d.ts
+++ b/packages/providers/cmr-stac.d.ts
@@ -1,0 +1,18 @@
+export declare const slug = "nasa-cmr-stac";
+export declare const baseUrl = "https://cmr.earthdata.nasa.gov/stac";
+export interface Params {
+    catalog: string;
+    bbox: number[];
+    datetime?: string;
+    collections?: string[];
+}
+export interface Request {
+    url: string;
+    body: {
+        bbox: number[];
+        datetime?: string;
+        collections?: string[];
+    };
+}
+export declare function buildRequest({ catalog, bbox, datetime, collections }: Params): Request;
+export declare function fetchJson(url: string, body: any): Promise<any>;

--- a/packages/providers/cmr-stac.js
+++ b/packages/providers/cmr-stac.js
@@ -1,0 +1,28 @@
+export const slug = 'nasa-cmr-stac';
+export const baseUrl = 'https://cmr.earthdata.nasa.gov/stac';
+export function buildRequest({ catalog, bbox, datetime, collections }) {
+    const body = { bbox };
+    if (datetime)
+        body.datetime = datetime;
+    if (collections)
+        body.collections = collections;
+    return {
+        url: `${baseUrl}/${catalog}/search`,
+        body,
+    };
+}
+export async function fetchJson(url, body) {
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+    const token = process.env.EARTHDATA_TOKEN;
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+    const res = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+    });
+    return res.json();
+}

--- a/packages/providers/cmr-stac.ts
+++ b/packages/providers/cmr-stac.ts
@@ -1,0 +1,44 @@
+export const slug = 'nasa-cmr-stac';
+export const baseUrl = 'https://cmr.earthdata.nasa.gov/stac';
+
+export interface Params {
+  catalog: string;
+  bbox: number[];
+  datetime?: string;
+  collections?: string[];
+}
+
+export interface Request {
+  url: string;
+  body: {
+    bbox: number[];
+    datetime?: string;
+    collections?: string[];
+  };
+}
+
+export function buildRequest({ catalog, bbox, datetime, collections }: Params): Request {
+  const body: any = { bbox };
+  if (datetime) body.datetime = datetime;
+  if (collections) body.collections = collections;
+  return {
+    url: `${baseUrl}/${catalog}/search`,
+    body,
+  };
+}
+
+export async function fetchJson(url: string, body: any): Promise<any> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const token = process.env.EARTHDATA_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as cmrstac from './cmr-stac.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as cmrstac from './cmr-stac.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -2,3 +2,4 @@ export * as nws from './nws.js';
 export * as metno from './metno.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as cmrstac from './cmr-stac.js';

--- a/packages/providers/test/cmr-stac.test.ts
+++ b/packages/providers/test/cmr-stac.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../cmr-stac.js';
+
+describe('cmr-stac provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.EARTHDATA_TOKEN;
+  });
+
+  it('builds search request body', () => {
+    const req = buildRequest({
+      catalog: 'LANCE',
+      bbox: [1, 2, 3, 4],
+      datetime: '2024-01-01/2024-01-02',
+      collections: ['MODIS'],
+    });
+    expect(req.url).toBe('https://cmr.earthdata.nasa.gov/stac/LANCE/search');
+    expect(req.body).toEqual({
+      bbox: [1, 2, 3, 4],
+      datetime: '2024-01-01/2024-01-02',
+      collections: ['MODIS'],
+    });
+  });
+
+  it('adds Authorization header when token present', async () => {
+    process.env.EARTHDATA_TOKEN = 'token';
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const { url, body } = buildRequest({ catalog: 'LANCE', bbox: [1, 2, 3, 4] });
+    await fetchJson(url, body);
+    expect(mock).toHaveBeenCalledWith(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      },
+      body: JSON.stringify({ bbox: [1, 2, 3, 4] }),
+    });
+  });
+
+  it('omits Authorization header when token missing', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const { url, body } = buildRequest({ catalog: 'LANCE', bbox: [1, 2, 3, 4] });
+    await fetchJson(url, body);
+    expect(mock).toHaveBeenCalledWith(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ bbox: [1, 2, 3, 4] }),
+    });
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -2,5 +2,6 @@
   {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "nasa-cmr-stac", "category": "satellite", "accessRoute": "REST", "baseUrl": "https://cmr.earthdata.nasa.gov/stac"}
 ]


### PR DESCRIPTION
## Summary
- add CMR STAC provider with POST search requests and optional Earthdata auth token
- export provider in index and add to manifest
- test request body and conditional Authorization header

## Testing
- `pnpm --filter @atmos/providers test`
- `pnpm lint` *(fails: Unexpected any. Specify a different type @ apps/web/src/app/page.tsx:71:25)*

------
https://chatgpt.com/codex/tasks/task_e_68b348ce20f88323a63e407289424c04