### PR TITLE
feat: expand weather providers manifest

### DIFF
--- a/packages/providers/dwd.d.ts
+++ b/packages/providers/dwd.d.ts
@@ -1,0 +1,7 @@
+export declare const slug = "dwd-opendata";
+export declare const baseUrl = "https://opendata.dwd.de";
+export interface Params {
+    path: string;
+}
+export declare function buildRequest({ path }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/dwd.js
+++ b/packages/providers/dwd.js
@@ -1,0 +1,9 @@
+export const slug = 'dwd-opendata';
+export const baseUrl = 'https://opendata.dwd.de';
+export function buildRequest({ path }) {
+    return `${baseUrl}/${path}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/dwd.ts
+++ b/packages/providers/dwd.ts
@@ -1,0 +1,15 @@
+export const slug = 'dwd-opendata';
+export const baseUrl = 'https://opendata.dwd.de';
+
+export interface Params {
+  path: string;
+}
+
+export function buildRequest({ path }: Params): string {
+  return `${baseUrl}/${path}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/fmi.d.ts
+++ b/packages/providers/fmi.d.ts
@@ -1,0 +1,7 @@
+export declare const slug = "fmi-opendata";
+export declare const baseUrl = "https://opendata.fmi.fi";
+export interface Params {
+    path: string;
+}
+export declare function buildRequest({ path }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/fmi.js
+++ b/packages/providers/fmi.js
@@ -1,0 +1,9 @@
+export const slug = 'fmi-opendata';
+export const baseUrl = 'https://opendata.fmi.fi';
+export function buildRequest({ path }) {
+    return `${baseUrl}/${path}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/fmi.ts
+++ b/packages/providers/fmi.ts
@@ -1,0 +1,15 @@
+export const slug = 'fmi-opendata';
+export const baseUrl = 'https://opendata.fmi.fi';
+
+export interface Params {
+  path: string;
+}
+
+export function buildRequest({ path }: Params): string {
+  return `${baseUrl}/${path}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/index.d.ts
+++ b/packages/providers/index.d.ts
@@ -1,4 +1,8 @@
-export * as nws from './nws.js';
+export * as dwd from './dwd.js';
+export * as fmi from './fmi.js';
 export * as metno from './metno.js';
+export * as msc from './msc.js';
+export * as nws from './nws.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as smhi from './smhi.js';

--- a/packages/providers/index.js
+++ b/packages/providers/index.js
@@ -1,4 +1,8 @@
-export * as nws from './nws.js';
+export * as dwd from './dwd.js';
+export * as fmi from './fmi.js';
 export * as metno from './metno.js';
+export * as msc from './msc.js';
+export * as nws from './nws.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as smhi from './smhi.js';

--- a/packages/providers/index.ts
+++ b/packages/providers/index.ts
@@ -1,4 +1,8 @@
-export * as nws from './nws.js';
+export * as dwd from './dwd.js';
+export * as fmi from './fmi.js';
 export * as metno from './metno.js';
+export * as msc from './msc.js';
+export * as nws from './nws.js';
 export * as openmeteo from './openmeteo.js';
 export * as openweather from './openweather.js';
+export * as smhi from './smhi.js';

--- a/packages/providers/msc.d.ts
+++ b/packages/providers/msc.d.ts
@@ -1,0 +1,7 @@
+export declare const slug = "msc-geomet";
+export declare const baseUrl = "https://geo.weather.gc.ca/geomet";
+export interface Params {
+    path: string;
+}
+export declare function buildRequest({ path }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/msc.js
+++ b/packages/providers/msc.js
@@ -1,0 +1,9 @@
+export const slug = 'msc-geomet';
+export const baseUrl = 'https://geo.weather.gc.ca/geomet';
+export function buildRequest({ path }) {
+    return `${baseUrl}/${path}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/msc.ts
+++ b/packages/providers/msc.ts
@@ -1,0 +1,15 @@
+export const slug = 'msc-geomet';
+export const baseUrl = 'https://geo.weather.gc.ca/geomet';
+
+export interface Params {
+  path: string;
+}
+
+export function buildRequest({ path }: Params): string {
+  return `${baseUrl}/${path}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/smhi.d.ts
+++ b/packages/providers/smhi.d.ts
@@ -1,0 +1,7 @@
+export declare const slug = "smhi-opendata";
+export declare const baseUrl = "https://opendata-download-metfcst.smhi.se";
+export interface Params {
+    path: string;
+}
+export declare function buildRequest({ path }: Params): string;
+export declare function fetchJson(url: string): Promise<any>;

--- a/packages/providers/smhi.js
+++ b/packages/providers/smhi.js
@@ -1,0 +1,9 @@
+export const slug = 'smhi-opendata';
+export const baseUrl = 'https://opendata-download-metfcst.smhi.se';
+export function buildRequest({ path }) {
+    return `${baseUrl}/${path}`;
+}
+export async function fetchJson(url) {
+    const res = await fetch(url);
+    return res.json();
+}

--- a/packages/providers/smhi.ts
+++ b/packages/providers/smhi.ts
@@ -1,0 +1,15 @@
+export const slug = 'smhi-opendata';
+export const baseUrl = 'https://opendata-download-metfcst.smhi.se';
+
+export interface Params {
+  path: string;
+}
+
+export function buildRequest({ path }: Params): string {
+  return `${baseUrl}/${path}`;
+}
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  return res.json();
+}

--- a/packages/providers/test/dwd.test.ts
+++ b/packages/providers/test/dwd.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../dwd.js';
+
+describe('dwd provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds path URL', () => {
+    const url = buildRequest({ path: 'test' });
+    expect(url).toBe('https://opendata.dwd.de/test');
+  });
+
+  it('fetches JSON', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ path: 'test' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/test/fmi.test.ts
+++ b/packages/providers/test/fmi.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../fmi.js';
+
+describe('fmi provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds path URL', () => {
+    const url = buildRequest({ path: 'test' });
+    expect(url).toBe('https://opendata.fmi.fi/test');
+  });
+
+  it('fetches JSON', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ path: 'test' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/test/manifest.test.ts
+++ b/packages/providers/test/manifest.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import * as providers from '../index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const manifest = JSON.parse(
+  readFileSync(resolve(__dirname, '../../../providers.json'), 'utf-8')
+);
+
+describe('provider manifest', () => {
+  it('matches exports and is sorted', () => {
+    const exportedSlugs = Object.values(providers).map((p: any) => p.slug).sort();
+    const manifestSlugs = manifest.map((p: any) => p.slug);
+    expect(manifestSlugs).toEqual([...manifestSlugs].sort());
+    expect(manifestSlugs).toEqual(exportedSlugs);
+  });
+});

--- a/packages/providers/test/msc.test.ts
+++ b/packages/providers/test/msc.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../msc.js';
+
+describe('msc provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds path URL', () => {
+    const url = buildRequest({ path: 'wms' });
+    expect(url).toBe('https://geo.weather.gc.ca/geomet/wms');
+  });
+
+  it('fetches JSON', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ path: 'wms' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/packages/providers/test/smhi.test.ts
+++ b/packages/providers/test/smhi.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildRequest, fetchJson } from '../smhi.js';
+
+describe('smhi provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds path URL', () => {
+    const url = buildRequest({ path: 'test' });
+    expect(url).toBe('https://opendata-download-metfcst.smhi.se/test');
+  });
+
+  it('fetches JSON', async () => {
+    const mock = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    // @ts-ignore
+    global.fetch = mock;
+    const url = buildRequest({ path: 'test' });
+    await fetchJson(url);
+    expect(mock).toHaveBeenCalledWith(url);
+  });
+});

--- a/providers.json
+++ b/providers.json
@@ -1,6 +1,10 @@
 [
-  {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
+  {"slug": "dwd-opendata", "category": "weather", "accessRoute": "OGC WMS/WFS", "baseUrl": "https://opendata.dwd.de"},
+  {"slug": "fmi-opendata", "category": "weather", "accessRoute": "OGC WFS/WMS", "baseUrl": "https://opendata.fmi.fi"},
   {"slug": "met-norway", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.met.no/weatherapi"},
+  {"slug": "msc-geomet", "category": "weather", "accessRoute": "OGC WMS/WFS/WMTS", "baseUrl": "https://geo.weather.gc.ca/geomet"},
+  {"slug": "nws-weather", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.weather.gov"},
   {"slug": "open-meteo", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.open-meteo.com"},
-  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"}
+  {"slug": "openweather-onecall", "category": "weather", "accessRoute": "REST", "baseUrl": "https://api.openweathermap.org"},
+  {"slug": "smhi-opendata", "category": "weather", "accessRoute": "REST", "baseUrl": "https://opendata-download-metfcst.smhi.se"}
 ]


### PR DESCRIPTION
## Summary
- add DWD, FMI, MSC GeoMet, and SMHI provider modules
- list new providers in central manifest and export from package entry
- verify provider manifest alignment via unit test

## Testing
- `pnpm --filter @atmos/providers build`
- `pnpm --filter @atmos/providers test`


------
https://chatgpt.com/codex/tasks/task_e_68b348cf53b0832389beb6839772dafa